### PR TITLE
0.5.0 updates

### DIFF
--- a/templates/android.js
+++ b/templates/android.js
@@ -7,8 +7,8 @@ module.exports = platform => [{
     }
 
     dependencies {
-        // Matches the RN Hello World template
-        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L8
+        // Matches recent template from React Native (0.59)
+        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L16
         classpath 'com.android.tools.build:gradle:3.3.2'
     }
 }
@@ -20,10 +20,12 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+// Matches values in recent template from React Native (0.59)
+// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
 def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = "28.0.2"
+def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
 def DEFAULT_MIN_SDK_VERSION = 16
-def DEFAULT_TARGET_SDK_VERSION = 27
+def DEFAULT_TARGET_SDK_VERSION = 28
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
@@ -43,8 +45,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches the RN Hello World template
-        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
+        // Matches recent template from React Native (0.59)
+        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
         url "$projectDir/../node_modules/react-native/android"
     }
     mavenCentral()

--- a/templates/general.js
+++ b/templates/general.js
@@ -88,7 +88,7 @@ ${name};
     const devDependencies =
       `{
     "react": "^16.5.0",
-    "react-native": "0.59.3"` +
+    "react-native": "^0.59.4"` +
         (withWindows
           ? `,
     "react-native-windows": "^0.57.1"`


### PR DESCRIPTION
- Android Gradle plugin 3.3.2 update as proposed in frostney/react-native-create-library#102
- Other generated Android build updates from React Native 0.59
- Update devDependencies for React Native 0.59.4