### PR TITLE
Include .swift files in podspec

### DIFF
--- a/templates/ios.js
+++ b/templates/ios.js
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/${githubAccount}/${moduleName}.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m}"
+  s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
   s.dependency "React"


### PR DESCRIPTION
Hey thanks for the development of this package!

I like to write my modules for swift, so after creating a new module with create-react-native-module I need to change the .podspec to include the swift files. 

If you think think this is a good idea, I would be happy if you can merge this PR!