### PR TITLE
[MAJOR BREAKING WIP] lib.js remove `react-native link` step for example

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -194,7 +194,6 @@ const generateWithOptions = ({
               console.error('Yarn failure for example, aborting');
               throw (e);
             }
-            execSync('react-native link', addLinkLibraryOptions);
 
             return resolve();
           });


### PR DESCRIPTION
as there is no need for this step on React Native 0.60(+)

This should be considered a MAJOR BREAKING change since it is expected to cause issues with older versions of React Native.

This change will not be merged before support for React Native pre-0.60 is completely removed.

Testing:

- [ ] check that it is still possible to run the generated example on Android & iOS React Native 0.60(+)
- [ ] automatic testing (see #40)