### PR TITLE
cleanup templates/*.js: remove zero max-len lines

### DIFF
--- a/templates/example.js
+++ b/templates/example.js
@@ -1,5 +1,3 @@
-/* eslint max-len: 0 */
-
 module.exports = [{
   name: () => 'scripts/examples_postinstall.js',
   content: ({ exampleName }) =>

--- a/templates/general.js
+++ b/templates/general.js
@@ -1,5 +1,3 @@
-/* eslint max-len: 0 */
-
 module.exports = [{
   name: () => 'README.md',
   content: ({ moduleName, packageIdentifier, name, namespace, platforms }) => {

--- a/templates/ios.js
+++ b/templates/ios.js
@@ -1,5 +1,3 @@
-/* eslint max-len: 0 */
-
 module.exports = platform => [{
   name: ({ moduleName }) => `${moduleName}.podspec`,
   content: ({ moduleName, githubAccount, authorName, authorEmail, useCocoapods }) => `require "json"

--- a/templates/windows.js
+++ b/templates/windows.js
@@ -1,4 +1,3 @@
-/* eslint max-len: 0 */
 const uuid = require('uuid').v1().toUpperCase();
 
 module.exports = platform => [{


### PR DESCRIPTION
(not needed)

In case this kind of customization is needed in the future, it should be done in `templates/.eslintrc.yml` rather than in any of the JavaScript source files.