### PR TITLE
cleanup: standard formatting with no semicolons

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,10 +2,6 @@ extends:
   - standard
 
 rules:
-  semi:
-    - error
-    - always
-
   comma-dangle:
     - error
     - arrays: only-multiline

--- a/cli.js
+++ b/cli.js
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
 
-const program = require('commander');
-const updateNotifier = require('update-notifier');
+const program = require('commander')
+const updateNotifier = require('update-notifier')
 
-const command = require('./lib/cli-command');
-const pkg = require('./package.json');
+const command = require('./lib/cli-command')
+const pkg = require('./package.json')
 
-updateNotifier({ pkg }).notify();
+updateNotifier({ pkg }).notify()
 
 program
   .version(pkg.version)
   .usage(command.usage)
   .description(command.description)
   .action(function runAction () {
-    command.func(arguments, {}, this.opts());
+    command.func(arguments, {}, this.opts())
   });
 
 (command.options || [])
@@ -22,10 +22,10 @@ program
     opt.description,
     opt.parse || (value => value),
     opt.default
-  ));
+  ))
 
-program.parse(process.argv);
+program.parse(process.argv)
 
 if (!program.args.length) {
-  program.help();
+  program.help()
 }

--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,8 @@ const updateNotifier = require('update-notifier')
 const command = require('./lib/cli-command')
 const pkg = require('./package.json')
 
+const commandOptions = command.options || []
+
 updateNotifier({ pkg }).notify()
 
 program
@@ -14,9 +16,9 @@ program
   .description(command.description)
   .action(function runAction () {
     command.func(arguments, {}, this.opts())
-  });
+  })
 
-(command.options || [])
+commandOptions
   .forEach(opt => program.option(
     opt.command,
     opt.description,

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -1,8 +1,8 @@
-const emoji = require('node-emoji');
+const emoji = require('node-emoji')
 
-const normalizedOptions = require('./normalized-options');
+const normalizedOptions = require('./normalized-options')
 
-const createLibraryModule = require('./lib');
+const createLibraryModule = require('./lib')
 
 const postCreateInstructions = ({ moduleName, useCocoapods, exampleName }) => {
   return `
@@ -19,24 +19,24 @@ cd ..
 `
     : ``}react-native run-ios
 ----
-`;
-};
+`
+}
 
 module.exports = {
   name: 'create-library',
   description: 'creates a React Native library module for one or more platforms',
   usage: '[options] <name>',
   func: (args, config, options) => {
-    const name = args[0];
+    const name = args[0]
 
-    const beforeCreation = Date.now();
+    const beforeCreation = Date.now()
 
     const platforms = (options.platforms)
-      ? options.platforms.split(',') : options.platforms;
+      ? options.platforms.split(',') : options.platforms
 
     const preNormalizedOptions = Object.assign({}, { name }, options, {
       platforms
-    });
+    })
 
     // NOTE: There is a trick where the new normalizedOptions()
     // from normalized-options.js is applied by both command.js & lib.js.
@@ -44,22 +44,22 @@ module.exports = {
     // final log message, and that the exported programmatic
     // function can be completely tested from using the CLI.
 
-    const createOptions = normalizedOptions(preNormalizedOptions);
+    const createOptions = normalizedOptions(preNormalizedOptions)
 
-    const rootModuleName = createOptions.moduleName;
+    const rootModuleName = createOptions.moduleName
 
     createLibraryModule(createOptions).then(() => {
       console.log(`
 ${emoji.get('books')}  Created library module ${rootModuleName} in \`./${rootModuleName}\`.
 ${emoji.get('clock9')}  It took ${Date.now() - beforeCreation}ms.
-${postCreateInstructions(createOptions)}`);
+${postCreateInstructions(createOptions)}`)
     }).catch((err) => {
-      console.error(`Error while creating library module ${rootModuleName}`);
+      console.error(`Error while creating library module ${rootModuleName}`)
 
       if (err.stack) {
-        console.error(err.stack);
+        console.error(err.stack)
       }
-    });
+    })
   },
   options: [{
     command: '--prefix [prefix]',
@@ -114,4 +114,4 @@ ${postCreateInstructions(createOptions)}`);
     description: 'React Native version for the generated example project',
     default: 'react-native@0.59',
   }]
-};
+}

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -1,48 +1,48 @@
-const path = require('path');
+const path = require('path')
 
 // default fs object
-const fsExtra = require('fs-extra');
+const fsExtra = require('fs-extra')
 
-const jsonfileDefault = require('jsonfile');
+const jsonfileDefault = require('jsonfile')
 
-const normalizedOptions = require('./normalized-options');
+const normalizedOptions = require('./normalized-options')
 
 // FUTURE TODO: import from templates/example here
-const templates = require('../templates');
+const templates = require('../templates')
 // (...)
-const { npmAddScriptSync } = require('./utils');
-const { execSync } = require('child_process');
+const { npmAddScriptSync } = require('./utils')
+const { execSync } = require('child_process')
 
 // TBD FAKE execa object for now:
-const execaDefault = { commandSync: execSync };
+const execaDefault = { commandSync: execSync }
 // ALSO TESTED with the REAL execa - imported as follows:
 // const execaDefault = require('execa');
 // (with execa package added to package.json, of course)
 
-const DEFAULT_PREFIX = '';
-const DEFAULT_PACKAGE_IDENTIFIER = 'com.reactlibrary';
-const DEFAULT_PLATFORMS = ['android', 'ios'];
-const DEFAULT_GITHUB_ACCOUNT = 'github_account';
-const DEFAULT_AUTHOR_NAME = 'Your Name';
-const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com';
-const DEFAULT_LICENSE = 'MIT';
-const DEFAULT_USE_COCOAPODS = false;
-const DEFAULT_GENERATE_EXAMPLE = false;
-const DEFAULT_EXAMPLE_NAME = 'example';
-const DEFAULT_EXAMPLE_REACT_NATIVE_VERSION = 'react-native@0.59';
+const DEFAULT_PREFIX = ''
+const DEFAULT_PACKAGE_IDENTIFIER = 'com.reactlibrary'
+const DEFAULT_PLATFORMS = ['android', 'ios']
+const DEFAULT_GITHUB_ACCOUNT = 'github_account'
+const DEFAULT_AUTHOR_NAME = 'Your Name'
+const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com'
+const DEFAULT_LICENSE = 'MIT'
+const DEFAULT_USE_COCOAPODS = false
+const DEFAULT_GENERATE_EXAMPLE = false
+const DEFAULT_EXAMPLE_NAME = 'example'
+const DEFAULT_EXAMPLE_REACT_NATIVE_VERSION = 'react-native@0.59'
 
 const renderTemplateIfValid = (fs, root, template, templateArgs) => {
   // avoid throwing an exception in case there is no valid template.name member
-  const name = !!template.name && template.name(templateArgs);
-  if (!name) return Promise.resolve();
+  const name = !!template.name && template.name(templateArgs)
+  if (!name) return Promise.resolve()
 
-  const filename = path.join(root, name);
-  const [baseDir] = filename.split(path.basename(filename));
+  const filename = path.join(root, name)
+  const [baseDir] = filename.split(path.basename(filename))
 
   return fs.ensureDir(baseDir).then(() =>
     fs.outputFile(filename, template.content(templateArgs))
-  );
-};
+  )
+}
 
 const generateWithOptions = ({
   name = 'unknown', // (should be normalized)
@@ -68,7 +68,7 @@ const generateWithOptions = ({
 }) => {
   if (packageIdentifier === DEFAULT_PACKAGE_IDENTIFIER) {
     console.warn(`While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
-      identifier, it is recommended to customize the package identifier.`);
+      identifier, it is recommended to customize the package identifier.`)
   }
 
   // Note that the some of these console log messages are done as
@@ -93,51 +93,51 @@ const generateWithOptions = ({
   useCocoapods: ${useCocoapods}
   generateExample: ${generateExample}
   exampleName: ${exampleName}
-  `);
+  `)
 
   // QUICK LOCAL INJECTION overwite of existing execSync call from
   // mockable execa object for now (at least):
-  const execSync = execa.commandSync;
+  const execSync = execa.commandSync
 
   if (generateExample) {
-    const reactNativeVersionCommand = 'react-native --version';
-    const yarnVersionCommand = 'yarn --version';
+    const reactNativeVersionCommand = 'react-native --version'
+    const yarnVersionCommand = 'yarn --version'
 
-    const checkCliOptions = { stdio: 'inherit' };
-    const errorRemedyMessage = 'both react-native-cli and yarn CLI tools are needed to generate example project';
+    const checkCliOptions = { stdio: 'inherit' }
+    const errorRemedyMessage = 'both react-native-cli and yarn CLI tools are needed to generate example project'
 
     try {
-      console.info('CREATE: Check for valid react-native-cli tool version, as needed to generate the example project');
-      execSync(reactNativeVersionCommand, checkCliOptions);
-      console.info(`${reactNativeVersionCommand} ok`);
+      console.info('CREATE: Check for valid react-native-cli tool version, as needed to generate the example project')
+      execSync(reactNativeVersionCommand, checkCliOptions)
+      console.info(`${reactNativeVersionCommand} ok`)
     } catch (e) {
       throw new Error(
-        `${reactNativeVersionCommand} failed; ${errorRemedyMessage}`);
+        `${reactNativeVersionCommand} failed; ${errorRemedyMessage}`)
     }
 
     try {
-      console.info('CREATE: Check for valid Yarn CLI tool version, as needed to generate the example project');
-      execSync(yarnVersionCommand, checkCliOptions);
-      console.info(`${yarnVersionCommand} ok`);
+      console.info('CREATE: Check for valid Yarn CLI tool version, as needed to generate the example project')
+      execSync(yarnVersionCommand, checkCliOptions)
+      console.info(`${yarnVersionCommand} ok`)
     } catch (e) {
       throw new Error(
-        `${yarnVersionCommand} failed; ${errorRemedyMessage}`);
+        `${yarnVersionCommand} failed; ${errorRemedyMessage}`)
     }
   }
 
-  console.info('CREATE: Generating the React Native library module');
+  console.info('CREATE: Generating the React Native library module')
 
   const generateWithoutExample = () => {
     return fs.ensureDir(moduleName).then(() => {
       return Promise.all(templates.filter((template) => {
         if (template.platform) {
-          return (platforms.indexOf(template.platform) >= 0);
+          return (platforms.indexOf(template.platform) >= 0)
         }
 
-        return true;
+        return true
       }).map((template) => {
         if (!template.name) {
-          return Promise.resolve();
+          return Promise.resolve()
         }
         const templateArgs = {
           name: className,
@@ -153,24 +153,24 @@ const generateWithOptions = ({
           useCocoapods,
           generateExample,
           exampleName,
-        };
+        }
 
-        return renderTemplateIfValid(fs, moduleName, template, templateArgs);
-      }));
-    });
-  };
+        return renderTemplateIfValid(fs, moduleName, template, templateArgs)
+      }))
+    })
+  }
 
   // The separate promise makes it easier to generate
   // multiple test/sample projects, if needed.
   const generateExampleWithName =
     (exampleName) => {
       const exampleReactNativeInitCommand =
-        `react-native init ${exampleName} --version ${exampleReactNativeVersion}`;
+        `react-native init ${exampleName} --version ${exampleReactNativeVersion}`
 
       console.info(
-        `CREATE example app with the following command: ${exampleReactNativeInitCommand}`);
+        `CREATE example app with the following command: ${exampleReactNativeInitCommand}`)
 
-      const execOptions = { cwd: `./${moduleName}`, stdio: 'inherit' };
+      const execOptions = { cwd: `./${moduleName}`, stdio: 'inherit' }
 
       // (with the work done in a promise chain)
       return Promise.resolve()
@@ -179,11 +179,11 @@ const generateWithOptions = ({
           // its stdout to stdout in this process.
           // Note that any exception would be propoerly handled since this
           // call is executed within a Promise.resolve().then() callback.
-          execSync(exampleReactNativeInitCommand, execOptions);
+          execSync(exampleReactNativeInitCommand, execOptions)
         })
         .then(() => {
           // Execute the example template
-          const exampleTemplates = require('../templates/example');
+          const exampleTemplates = require('../templates/example')
 
           const templateArgs = {
             name: className,
@@ -191,49 +191,49 @@ const generateWithOptions = ({
             view,
             useCocoapods,
             exampleName,
-          };
+          }
 
           return Promise.all(
             exampleTemplates.map((template) => {
-              return renderTemplateIfValid(fs, moduleName, template, templateArgs);
+              return renderTemplateIfValid(fs, moduleName, template, templateArgs)
             })
-          );
+          )
         })
         .then(() => {
           // Adds and link the new library
           return new Promise((resolve, reject) => {
             // Add postinstall script to the example package.json
-            console.info('Adding cleanup postinstall task to the example app');
-            const pathExampleApp = `./${moduleName}/${exampleName}`;
+            console.info('Adding cleanup postinstall task to the example app')
+            const pathExampleApp = `./${moduleName}/${exampleName}`
             npmAddScriptSync(`${pathExampleApp}/package.json`, {
               key: 'postinstall',
               value: `node ../scripts/examples_postinstall.js`
-            }, jsonfile);
+            }, jsonfile)
 
             // Add and link the new library
-            console.info('Linking the new module library to the example app');
-            const addLinkLibraryOptions = { cwd: pathExampleApp, stdio: 'inherit' };
+            console.info('Linking the new module library to the example app')
+            const addLinkLibraryOptions = { cwd: pathExampleApp, stdio: 'inherit' }
             try {
-              execSync('yarn add file:../', addLinkLibraryOptions);
+              execSync('yarn add file:../', addLinkLibraryOptions)
             } catch (e) {
-              console.error('Yarn failure for example, aborting');
-              throw (e);
+              console.error('Yarn failure for example, aborting')
+              throw (e)
             }
-            execSync('react-native link', addLinkLibraryOptions);
+            execSync('react-native link', addLinkLibraryOptions)
 
-            return resolve();
-          });
-        });
-    };
+            return resolve()
+          })
+        })
+    }
 
   return generateWithoutExample().then(() => {
     return (generateExample
       ? generateExampleWithName(exampleName)
       : Promise.resolve()
-    );
-  });
-};
+    )
+  })
+}
 
 module.exports = (options) => {
-  return generateWithOptions(normalizedOptions(options));
-};
+  return generateWithOptions(normalizedOptions(options))
+}

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -1,26 +1,26 @@
-const paramCase = require('param-case');
+const paramCase = require('param-case')
 
-const pascalCase = require('pascal-case');
+const pascalCase = require('pascal-case')
 
 // TODO: refactor all defaults from here & lib.js into a new module
-const DEFAULT_MODULE_PREFIX = 'react-native';
+const DEFAULT_MODULE_PREFIX = 'react-native'
 
 module.exports = (options) => {
-  const name = options.name;
+  const name = options.name
 
-  const prefix = options.prefix || '';
+  const prefix = options.prefix || ''
 
-  const modulePrefix = options.modulePrefix || DEFAULT_MODULE_PREFIX;
+  const modulePrefix = options.modulePrefix || DEFAULT_MODULE_PREFIX
 
   if (typeof name !== 'string') {
-    throw new Error('Please write your library\'s name');
+    throw new Error('Please write your library\'s name')
   }
 
-  const moduleName = options.moduleName;
+  const moduleName = options.moduleName
 
   // OPTIONS NOT DOCUMENTED, not supported by CLI:
-  const className = options.className;
-  const namespace = options.namespace;
+  const className = options.className
+  const namespace = options.namespace
 
   return Object.assign(
     { name, prefix, modulePrefix },
@@ -40,5 +40,5 @@ module.exports = (options) => {
     namespace
       ? {}
       : { namespace: pascalCase(name).split(/(?=[A-Z])/).join('.') },
-  );
-};
+  )
+}

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,5 +1,5 @@
-const npmAddScriptSync = require('./npmAddScriptSync');
+const npmAddScriptSync = require('./npmAddScriptSync')
 
 module.exports = {
   npmAddScriptSync,
-};
+}

--- a/lib/utils/npmAddScriptSync.js
+++ b/lib/utils/npmAddScriptSync.js
@@ -3,18 +3,18 @@
 // with mockable jsonfile parameter
 module.exports = (packageJsonPath, script, jsonfile) => {
   try {
-    var packageJson = jsonfile.readFileSync(packageJsonPath);
-    if (!packageJson.scripts) packageJson.scripts = {};
+    var packageJson = jsonfile.readFileSync(packageJsonPath)
+    if (!packageJson.scripts) packageJson.scripts = {}
     if (!script.force && packageJson.scripts[script.key]) {
-      throw new Error(`That script entry for key: ${script.key} already exists.`);
+      throw new Error(`That script entry for key: ${script.key} already exists.`)
     }
-    packageJson.scripts[script.key] = script.value;
-    jsonfile.writeFileSync(packageJsonPath, packageJson, { spaces: 2 });
+    packageJson.scripts[script.key] = script.value
+    jsonfile.writeFileSync(packageJsonPath, packageJson, { spaces: 2 })
   } catch (e) {
     if (e.message === 'ENOENT, no such file or directory \'package.json\'') {
-      throw new Error(`The package.json at path: ${packageJsonPath} does not exist.`);
+      throw new Error(`The package.json at path: ${packageJsonPath} does not exist.`)
     } else {
-      throw e;
+      throw e
     }
   }
-};
+}

--- a/templates/android.js
+++ b/templates/android.js
@@ -282,4 +282,4 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 4. Run \`sudo ./gradlew installArchives\`
 5. Verify that latest set of generated files is in the maven folder with the correct version number
 `
-}];
+}]

--- a/templates/example.js
+++ b/templates/example.js
@@ -226,4 +226,4 @@ const styles = StyleSheet.create({
   },
 });
 `
-}];
+}]

--- a/templates/general.js
+++ b/templates/general.js
@@ -1,7 +1,7 @@
 module.exports = [{
   name: () => 'README.md',
   content: ({ moduleName, packageIdentifier, name, namespace, platforms }) => {
-    let manualInstallation = '';
+    let manualInstallation = ''
 
     if (platforms.indexOf('ios') >= 0) {
       manualInstallation += `
@@ -11,7 +11,7 @@ module.exports = [{
 2. Go to \`node_modules\` ➜ \`${moduleName}\` and add \`${name}.xcodeproj\`
 3. In XCode, in the project navigator, select your project. Add \`lib${name}.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
 4. Run your project (\`Cmd+R\`)<
-`;
+`
     }
 
     if (platforms.indexOf('android') >= 0) {
@@ -30,7 +30,7 @@ module.exports = [{
   	\`\`\`
       compile project(':${moduleName}')
   	\`\`\`
-`;
+`
     }
 
     if (platforms.indexOf('windows') >= 0) {
@@ -42,7 +42,7 @@ module.exports = [{
 2. Open up your \`MainPage.cs\` app
   - Add \`using ${namespace}.${name};\` to the usings at the top of the file
   - Add \`new ${name}Package()\` to the \`List<IReactPackage>\` returned by the \`Packages\` method
-`;
+`
     }
 
     return `# ${moduleName}
@@ -66,12 +66,12 @@ import ${name} from '${moduleName}';
 // TODO: What to do with the module?
 ${name};
 \`\`\`
-`;
+`
   },
 }, {
   name: () => 'package.json',
   content: ({ moduleName, platforms, githubAccount, authorName, authorEmail, license }) => {
-    const withWindows = platforms.indexOf('windows') >= 0;
+    const withWindows = platforms.indexOf('windows') >= 0
 
     const peerDependencies =
       `{
@@ -81,7 +81,7 @@ ${name};
         ? `,
     "react-native-windows": ">=0.57.0-rc.0 <1.0.x"`
         : ``) + `
-  }`;
+  }`
 
     const devDependencies =
       `{
@@ -91,7 +91,7 @@ ${name};
           ? `,
     "react-native-windows": "^0.57.1"`
           : ``) + `
-  }`;
+  }`
 
     return `{
   "name": "${moduleName}",
@@ -120,7 +120,7 @@ ${name};
   "peerDependencies": ${peerDependencies},
   "devDependencies": ${devDependencies}
 }
-`;
+`
   },
 }, {
   // for module without view:
@@ -154,7 +154,7 @@ export default ${name};
 node_modules/
 npm-debug.log
 yarn-error.log
-`;
+`
 
     if (platforms.indexOf('ios') >= 0) {
       content +=
@@ -178,7 +178,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-`;
+`
     }
 
     if (platforms.indexOf('android') >= 0) {
@@ -196,27 +196,27 @@ local.properties
 buck-out/
 \\.buckd/
 *.keystore
-`;
+`
     }
 
-    return content;
+    return content
   },
 }, {
   name: () => '.gitattributes',
   content: ({ platforms }) => {
     if (platforms.indexOf('ios') >= 0) {
-      return '*.pbxproj -text\n';
+      return '*.pbxproj -text\n'
     }
 
-    return '';
+    return ''
   }
 }, {
   name: () => '.npmignore',
   content: ({ generateExample, exampleName }) => {
     if (generateExample) {
-      return `${exampleName}\n`;
+      return `${exampleName}\n`
     }
 
-    return '';
+    return ''
   }
-}];
+}]

--- a/templates/index.js
+++ b/templates/index.js
@@ -1,14 +1,14 @@
-const android = require('./android')('android');
-const ios = require('./ios')('ios');
-const windows = require('./windows')('windows');
+const android = require('./android')('android')
+const ios = require('./ios')('ios')
+const windows = require('./windows')('windows')
 
-const general = require('./general');
+const general = require('./general')
 
-const updatePlatformInFile = platform => file => Object.assign(file, { platform });
+const updatePlatformInFile = platform => file => Object.assign(file, { platform })
 
 module.exports = [].concat(
   general,
   android.map(updatePlatformInFile('android')),
   ios.map(updatePlatformInFile('ios')),
   windows.map(updatePlatformInFile('windows')),
-);
+)

--- a/templates/ios.js
+++ b/templates/ios.js
@@ -379,4 +379,4 @@ RCT_EXPORT_MODULE()
 	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
 }
 `,
-}];
+}]

--- a/templates/windows.js
+++ b/templates/windows.js
@@ -1,4 +1,4 @@
-const uuid = require('uuid').v1().toUpperCase();
+const uuid = require('uuid').v1().toUpperCase()
 
 module.exports = platform => [{
   name: ({ name }) => `${platform}/${name}.sln`,
@@ -523,4 +523,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: ComVisible(false)]
   `,
-}];
+}]

--- a/tests/helpers/io-mocks.js
+++ b/tests/helpers/io-mocks.js
@@ -7,31 +7,31 @@ content:
 --------
 ${content}
 <<<<<<<< ======== >>>>>>>>
-`);
+`)
 
-      return Promise.resolve();
+      return Promise.resolve()
     },
 
     ensureDir: (dir) => {
-      mysnap.push(`* ensureDir dir: ${dir}\n`);
-      return Promise.resolve();
+      mysnap.push(`* ensureDir dir: ${dir}\n`)
+      return Promise.resolve()
     },
   },
   execa: {
     commandSync: (command, options) => {
       mysnap.push(
-        `* execa.commandSync command: ${command} options: ${JSON.stringify(options)}\n`);
+        `* execa.commandSync command: ${command} options: ${JSON.stringify(options)}\n`)
     },
   },
   jsonfile: {
     readFileSync: (jsonPath) => {
       mysnap.push(
-        `* jsonfile.readFileSync jsonPath: ${jsonPath}\n`);
-      return { name: 'bogus', scripts: [] };
+        `* jsonfile.readFileSync jsonPath: ${jsonPath}\n`)
+      return { name: 'bogus', scripts: [] }
     },
     writeFileSync: (path, json, options) => {
       mysnap.push(
-        `* jsonfile.writeFileSync path: ${path} json ${JSON.stringify(json)} options ${JSON.stringify(options)}\n`);
+        `* jsonfile.writeFileSync path: ${path} json ${JSON.stringify(json)} options ${JSON.stringify(options)}\n`)
     },
   },
-});
+})

--- a/tests/lib-android-config-options/lib-android-config-options.test.js
+++ b/tests/lib-android-config-options/lib-android-config-options.test.js
@@ -1,11 +1,11 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi module with config options for Android only', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     platforms: ['android'],
@@ -15,8 +15,8 @@ test('create alice-bobbi module with config options for Android only', () => {
     authorEmail: 'contact@alice.me',
     license: 'ISC',
     fs: mocks.fs,
-  };
+  }
 
   return lib(options)
-    .then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+    .then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-defaults/lib-defaults.test.js
+++ b/tests/lib-defaults/lib-defaults.test.js
@@ -1,16 +1,16 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi module with defaults', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     name: 'alice-bobbi',
     fs: mocks.fs,
-  };
+  }
 
-  return lib(options).then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+  return lib(options).then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-example-config-options/lib-example-config-options.test.js
+++ b/tests/lib-example-config-options/lib-example-config-options.test.js
@@ -1,11 +1,11 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi module with example, with config options', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     name: 'alice-bobbi',
@@ -19,7 +19,7 @@ test('create alice-bobbi module with example, with config options', () => {
     fs: mocks.fs,
     execa: mocks.execa,
     jsonfile: mocks.jsonfile,
-  };
+  }
 
-  return lib(options).then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+  return lib(options).then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-example-defaults/lib-example-defaults.test.js
+++ b/tests/lib-example-defaults/lib-example-defaults.test.js
@@ -1,11 +1,11 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi module with defaults', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     name: 'alice-bobbi',
@@ -13,7 +13,7 @@ test('create alice-bobbi module with defaults', () => {
     fs: mocks.fs,
     execa: mocks.execa,
     jsonfile: mocks.jsonfile,
-  };
+  }
 
-  return lib(options).then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+  return lib(options).then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-ios-config-options/lib-ios-config-options.test.js
+++ b/tests/lib-ios-config-options/lib-ios-config-options.test.js
@@ -1,11 +1,11 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi module with config options for iOS only', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     platforms: ['ios'],
@@ -15,8 +15,8 @@ test('create alice-bobbi module with config options for iOS only', () => {
     authorEmail: 'contact@alice.me',
     license: 'ISC',
     fs: mocks.fs,
-  };
+  }
 
   return lib(options)
-    .then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+    .then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-view-android-config-options/lib-view-android-config-options.test.js
+++ b/tests/lib-view-android-config-options/lib-view-android-config-options.test.js
@@ -1,11 +1,11 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi view module with config options for Android only', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     platforms: ['android'],
@@ -16,8 +16,8 @@ test('create alice-bobbi view module with config options for Android only', () =
     license: 'ISC',
     view: true,
     fs: mocks.fs,
-  };
+  }
 
   return lib(options)
-    .then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+    .then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-view-defaults/lib-view-defaults.test.js
+++ b/tests/lib-view-defaults/lib-view-defaults.test.js
@@ -1,17 +1,17 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi view module with defaults', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     name: 'alice-bobbi',
     view: true,
     fs: mocks.fs,
-  };
+  }
 
-  return lib(options).then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+  return lib(options).then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-view-ios-config-options/lib-view-ios-config-options.test.js
+++ b/tests/lib-view-ios-config-options/lib-view-ios-config-options.test.js
@@ -1,11 +1,11 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi view module with config options for iOS only', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     platforms: ['ios'],
@@ -16,8 +16,8 @@ test('create alice-bobbi view module with config options for iOS only', () => {
     license: 'ISC',
     view: true,
     fs: mocks.fs,
-  };
+  }
 
   return lib(options)
-    .then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+    .then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-view-with-example-config-options/lib-view-with-example-config-options.test.js
+++ b/tests/lib-view-with-example-config-options/lib-view-with-example-config-options.test.js
@@ -1,11 +1,11 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi view module with example, with custom config options', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     name: 'alice-bobbi',
@@ -20,7 +20,7 @@ test('create alice-bobbi view module with example, with custom config options', 
     fs: mocks.fs,
     execa: mocks.execa,
     jsonfile: mocks.jsonfile,
-  };
+  }
 
-  return lib(options).then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+  return lib(options).then(() => { expect(mysnap).toMatchSnapshot() })
+})

--- a/tests/lib-view-with-example-defaults/lib-view-with-example-defaults.test.js
+++ b/tests/lib-view-with-example-defaults/lib-view-with-example-defaults.test.js
@@ -1,11 +1,11 @@
-const lib = require('../../lib/lib.js');
+const lib = require('../../lib/lib.js')
 
-const ioMocks = require('../helpers/io-mocks.js');
+const ioMocks = require('../helpers/io-mocks.js')
 
 test('create alice-bobbi view module with example, with defaults', () => {
-  const mysnap = [];
+  const mysnap = []
 
-  const mocks = ioMocks(mysnap);
+  const mocks = ioMocks(mysnap)
 
   const options = {
     name: 'alice-bobbi',
@@ -14,7 +14,7 @@ test('create alice-bobbi view module with example, with defaults', () => {
     fs: mocks.fs,
     execa: mocks.execa,
     jsonfile: mocks.jsonfile,
-  };
+  }
 
-  return lib(options).then(() => { expect(mysnap).toMatchSnapshot(); });
-});
+  return lib(options).then(() => { expect(mysnap).toMatchSnapshot() })
+})


### PR DESCRIPTION
- remove `semi: ["error", "always"]` eslint rule
- update the JavaScript sources using the following command: `yarn lint --fix`
- add internal `commandOptions` declaration & remove one more `;` in `cli.js`

Motivation:

- I think this makes the code a little cleaner. Semicolons in JavaScript should be needed vary rarely if at all if some good coding practices are applied. There was one case in `cli.js` where an internal declaration was needed to completely remove the use of semicolons.
- Reduce the number of changes that would be applied by using [`prettierx`](https://www.npmjs.com/package/prettierx) (my fork of Prettier) (see #5)

Testing:

- [x] `npm test` (equivalent to `yarn test`) passes in my work area
- [x] Travis CI build is green
- [ ] TODO: check that this tool continues to function properly with these changes applied (needed since `cli.js` is still not covered by automatic testing (#40))