### PR TITLE
cleanup internal updatePlatformInFile function in templates/index.js

### DIFF
--- a/templates/index.js
+++ b/templates/index.js
@@ -4,7 +4,8 @@ const windows = require('./windows')('windows');
 
 const general = require('./general');
 
-const updatePlatformInFile = platform => file => Object.assign(file, { platform });
+const updatePlatformInFile = platform => file =>
+  Object.assign({}, file, { platform });
 
 module.exports = [].concat(
   general,


### PR DESCRIPTION
in templates/index.js

* add a line break
* do not overwrite object from another module in `Object.assign()` call, as such an overwrite is not needed and is not good form

Testing done:

* `npm test` (equivalent to `yarn test`) succeeds in my work area
* verified that the Travis CI build is green

Note that I think there is no need to do manual integration testing of the CLI, as the existing tests verify that changes to `templates/*.js` do not break anything.

Discovered while working on some cleanup related to evaluating use of my [`prettierx`](https://www.npmjs.com/package/prettierx) fork of Prettier (#5).