### PR TITLE
 Cleaner ENOENT error message test

### DIFF
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -13,7 +13,7 @@ module.exports = (options) => {
   const modulePrefix = options.modulePrefix || DEFAULT_MODULE_PREFIX;
 
   if (typeof name !== 'string') {
-    throw new Error('Please write your library\'s name');
+    throw new TypeError("Please write your library's name");
   }
 
   const moduleName = options.moduleName;

--- a/lib/utils/npmAddScriptSync.js
+++ b/lib/utils/npmAddScriptSync.js
@@ -11,7 +11,7 @@ module.exports = (packageJsonPath, script, jsonfile) => {
     packageJson.scripts[script.key] = script.value;
     jsonfile.writeFileSync(packageJsonPath, packageJson, { spaces: 2 });
   } catch (e) {
-    if (/ENOENT.*no such file or directory.*package.json/.test(e.message) {
+    if (/ENOENT.*no such file or directory.*package.json/.test(e.message)) {
       throw new Error(`The package.json at path: ${packageJsonPath} does not exist.`);
     } else {
       throw e;

--- a/lib/utils/npmAddScriptSync.js
+++ b/lib/utils/npmAddScriptSync.js
@@ -11,7 +11,7 @@ module.exports = (packageJsonPath, script, jsonfile) => {
     packageJson.scripts[script.key] = script.value;
     jsonfile.writeFileSync(packageJsonPath, packageJson, { spaces: 2 });
   } catch (e) {
-    if (e.message === 'ENOENT, no such file or directory \'package.json\'') {
+    if (/ENOENT.*no such file or directory.*package.json/.test(e.message) {
       throw new Error(`The package.json at path: ${packageJsonPath} does not exist.`);
     } else {
       throw e;


### PR DESCRIPTION
in `lib/utils/npmAddScriptSync.js`

Testing TODO:

- [ ] Update the automatic test suite to cover testing of this error condition

Discovered through evaluation of using my [`prettierx`](https://www.npmjs.com/package/prettierx) fork of Prettier (#5) on this project.