### PR TITLE
jsonfile test updates & fixes

### DIFF
--- a/tests/helpers/io-mocks.js
+++ b/tests/helpers/io-mocks.js
@@ -17,21 +17,32 @@ ${content}
       return Promise.resolve();
     },
   },
+  jsonfile: { // FUTURE TBD may be combined with fs object above
+    readFileSync: (jsonFilePath) => {
+      mysnap.push({
+        call: 'jsonfile.readFileSync',
+        jsonFilePath,
+      });
+      return {
+        name: 'example',
+        scripts: {
+          test: 'echo "not implemented" && exit 1'
+        }
+      };
+    },
+    writeFileSync: (path, json, options) => {
+      mysnap.push({
+        call: 'jsonfile.writeFileSync',
+        filePath: path,
+        json,
+        options,
+      });
+    },
+  },
   execa: {
     commandSync: (command, options) => {
       mysnap.push(
         `* execa.commandSync command: ${command} options: ${JSON.stringify(options)}\n`);
-    },
-  },
-  jsonfile: {
-    readFileSync: (jsonPath) => {
-      mysnap.push(
-        `* jsonfile.readFileSync jsonPath: ${jsonPath}\n`);
-      return { name: 'bogus', scripts: [] };
-    },
-    writeFileSync: (path, json, options) => {
-      mysnap.push(
-        `* jsonfile.writeFileSync path: ${path} json ${JSON.stringify(json)} options ${JSON.stringify(options)}\n`);
     },
   },
 });

--- a/tests/lib-example-config-options/__snapshots__/lib-example-config-options.test.js.snap
+++ b/tests/lib-example-config-options/__snapshots__/lib-example-config-options.test.js.snap
@@ -963,10 +963,24 @@ const styles = StyleSheet.create({
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* jsonfile.readFileSync jsonPath: ./react-native-alice-bobbi/test-demo/package.json
-",
-  "* jsonfile.writeFileSync path: ./react-native-alice-bobbi/test-demo/package.json json {\\"name\\":\\"bogus\\",\\"scripts\\":[]} options {\\"spaces\\":2}
-",
+  Object {
+    "call": "jsonfile.readFileSync",
+    "jsonFilePath": "./react-native-alice-bobbi/test-demo/package.json",
+  },
+  Object {
+    "call": "jsonfile.writeFileSync",
+    "filePath": "./react-native-alice-bobbi/test-demo/package.json",
+    "json": Object {
+      "name": "example",
+      "scripts": Object {
+        "postinstall": "node ../scripts/examples_postinstall.js",
+        "test": "echo \\"not implemented\\" && exit 1",
+      },
+    },
+    "options": Object {
+      "spaces": 2,
+    },
+  },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}

--- a/tests/lib-example-defaults/__snapshots__/lib-example-defaults.test.js.snap
+++ b/tests/lib-example-defaults/__snapshots__/lib-example-defaults.test.js.snap
@@ -963,10 +963,24 @@ const styles = StyleSheet.create({
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* jsonfile.readFileSync jsonPath: ./react-native-alice-bobbi/example/package.json
-",
-  "* jsonfile.writeFileSync path: ./react-native-alice-bobbi/example/package.json json {\\"name\\":\\"bogus\\",\\"scripts\\":[]} options {\\"spaces\\":2}
-",
+  Object {
+    "call": "jsonfile.readFileSync",
+    "jsonFilePath": "./react-native-alice-bobbi/example/package.json",
+  },
+  Object {
+    "call": "jsonfile.writeFileSync",
+    "filePath": "./react-native-alice-bobbi/example/package.json",
+    "json": Object {
+      "name": "example",
+      "scripts": Object {
+        "postinstall": "node ../scripts/examples_postinstall.js",
+        "test": "echo \\"not implemented\\" && exit 1",
+      },
+    },
+    "options": Object {
+      "spaces": 2,
+    },
+  },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}

--- a/tests/lib-view-with-example-config-options/__snapshots__/lib-view-with-example-config-options.test.js.snap
+++ b/tests/lib-view-with-example-config-options/__snapshots__/lib-view-with-example-config-options.test.js.snap
@@ -955,10 +955,24 @@ const styles = StyleSheet.create({
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* jsonfile.readFileSync jsonPath: ./react-native-alice-bobbi/test-demo/package.json
-",
-  "* jsonfile.writeFileSync path: ./react-native-alice-bobbi/test-demo/package.json json {\\"name\\":\\"bogus\\",\\"scripts\\":[]} options {\\"spaces\\":2}
-",
+  Object {
+    "call": "jsonfile.readFileSync",
+    "jsonFilePath": "./react-native-alice-bobbi/test-demo/package.json",
+  },
+  Object {
+    "call": "jsonfile.writeFileSync",
+    "filePath": "./react-native-alice-bobbi/test-demo/package.json",
+    "json": Object {
+      "name": "example",
+      "scripts": Object {
+        "postinstall": "node ../scripts/examples_postinstall.js",
+        "test": "echo \\"not implemented\\" && exit 1",
+      },
+    },
+    "options": Object {
+      "spaces": 2,
+    },
+  },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}

--- a/tests/lib-view-with-example-defaults/__snapshots__/lib-view-with-example-defaults.test.js.snap
+++ b/tests/lib-view-with-example-defaults/__snapshots__/lib-view-with-example-defaults.test.js.snap
@@ -955,10 +955,24 @@ const styles = StyleSheet.create({
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* jsonfile.readFileSync jsonPath: ./react-native-alice-bobbi/example/package.json
-",
-  "* jsonfile.writeFileSync path: ./react-native-alice-bobbi/example/package.json json {\\"name\\":\\"bogus\\",\\"scripts\\":[]} options {\\"spaces\\":2}
-",
+  Object {
+    "call": "jsonfile.readFileSync",
+    "jsonFilePath": "./react-native-alice-bobbi/example/package.json",
+  },
+  Object {
+    "call": "jsonfile.writeFileSync",
+    "filePath": "./react-native-alice-bobbi/example/package.json",
+    "json": Object {
+      "name": "example",
+      "scripts": Object {
+        "postinstall": "node ../scripts/examples_postinstall.js",
+        "test": "echo \\"not implemented\\" && exit 1",
+      },
+    },
+    "options": Object {
+      "spaces": 2,
+    },
+  },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}


### PR DESCRIPTION
* return more realistic `package.json` object for generated `example`, which fixes capture of the new `scripts` entry that is added to the example `package.json` object

* push more formal object entries to the I/O snapshot

* move the mock `jsonfile` definition directly below the mock `fs` definition, to make it easier to combine them in the future