### PR TITLE
Drop support for React Native pre-0.59

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
 ### General status
 
 - **React Native versions supported:**
-  - recommended: 0.60 (see known quirks and issues below), 0.59
-  - deprecated: 0.58, 0.57 (see [issue #42](https://github.com/brodybits/create-react-native-module/issues/42))
+  - recommended: `0.60` (see known quirks and issues below)
+  - `0.59`
 - Known quirks & issues on React Native 0.60(+):
   - [issue #28](https://github.com/brodybits/create-react-native-module/issues/28) - additional `pod install` step needed for RN 0.60 on iOS
   - [issue #29](https://github.com/brodybits/create-react-native-module/issues/29) - View does not work with RN 0.60 on Android (quick patch needed)

--- a/templates/general.js
+++ b/templates/general.js
@@ -75,21 +75,21 @@ ${name};
 
     const peerDependencies =
       `{
-    "react": "^16.5.0",
-    "react-native": ">=0.57.0-rc.0 <1.0.x"` +
+    "react": "^16.8.1",
+    "react-native": ">=0.59.0-rc.0 <1.0.x"` +
       (withWindows
         ? `,
-    "react-native-windows": ">=0.57.0-rc.0 <1.0.x"`
+    "react-native-windows": ">=0.59.0-rc.0 <1.0.x"`
         : ``) + `
   }`;
 
     const devDependencies =
       `{
-    "react": "^16.5.0",
-    "react-native": "^0.59.4"` +
+    "react": "^16.8.3",
+    "react-native": "^0.59.10"` +
         (withWindows
           ? `,
-    "react-native-windows": "^0.57.1"`
+    "react-native-windows": "^0.59.0-rc.1"`
           : ``) + `
   }`;
 

--- a/tests/lib-android-config-options/__snapshots__/lib-android-config-options.test.js.snap
+++ b/tests/lib-android-config-options/__snapshots__/lib-android-config-options.test.js.snap
@@ -96,12 +96,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-cli-command/lib-cli-command-func-android-ios-config-options/__snapshots__/lib-cli-command-func-android-ios-config-options.test.js.snap
+++ b/tests/lib-cli-command/lib-cli-command-func-android-ios-config-options/__snapshots__/lib-cli-command-func-android-ios-config-options.test.js.snap
@@ -113,12 +113,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-defaults/__snapshots__/lib-defaults.test.js.snap
+++ b/tests/lib-defaults/__snapshots__/lib-defaults.test.js.snap
@@ -113,12 +113,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-example-config-options/__snapshots__/lib-example-config-options.test.js.snap
+++ b/tests/lib-example-config-options/__snapshots__/lib-example-config-options.test.js.snap
@@ -117,12 +117,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-example-defaults/__snapshots__/lib-example-defaults.test.js.snap
+++ b/tests/lib-example-defaults/__snapshots__/lib-example-defaults.test.js.snap
@@ -117,12 +117,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-ios-config-options/__snapshots__/lib-ios-config-options.test.js.snap
+++ b/tests/lib-ios-config-options/__snapshots__/lib-ios-config-options.test.js.snap
@@ -88,12 +88,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-view-android-config-options/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/lib-view-android-config-options/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -96,12 +96,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-view-defaults/__snapshots__/lib-view-defaults.test.js.snap
+++ b/tests/lib-view-defaults/__snapshots__/lib-view-defaults.test.js.snap
@@ -113,12 +113,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-view-ios-config-options/__snapshots__/lib-view-ios-config-options.test.js.snap
+++ b/tests/lib-view-ios-config-options/__snapshots__/lib-view-ios-config-options.test.js.snap
@@ -88,12 +88,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-view-with-example-config-options/__snapshots__/lib-view-with-example-config-options.test.js.snap
+++ b/tests/lib-view-with-example-config-options/__snapshots__/lib-view-with-example-config-options.test.js.snap
@@ -117,12 +117,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-view-with-example-defaults/__snapshots__/lib-view-with-example-defaults.test.js.snap
+++ b/tests/lib-view-with-example-defaults/__snapshots__/lib-view-with-example-defaults.test.js.snap
@@ -117,12 +117,12 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
   }
 }
 

--- a/tests/lib-windows-config-options/__snapshots__/lib-windows-config-options.test.js.snap
+++ b/tests/lib-windows-config-options/__snapshots__/lib-windows-config-options.test.js.snap
@@ -97,14 +97,14 @@ content:
   \\"licenseFilename\\": \\"LICENSE\\",
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\">=0.57.0-rc.0 <1.0.x\\",
-    \\"react-native-windows\\": \\">=0.57.0-rc.0 <1.0.x\\"
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\",
+    \\"react-native-windows\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.5.0\\",
-    \\"react-native\\": \\"^0.59.4\\",
-    \\"react-native-windows\\": \\"^0.57.1\\"
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\",
+    \\"react-native-windows\\": \\"^0.59.0-rc.1\\"
   }
 }
 


### PR DESCRIPTION
and update README.md

resolves #42

Testing:

- [x] `npm test` passes on workstation
- [x] check that the Travis CI build is green
- [x] test ability to create working React Native library module with working example