### PR TITLE
❌EXTRA BREAKING MUTATION 1a: ignore `useCocoapods` in generateLibraryM…

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -150,7 +150,6 @@ const generateWithOptions = ({
           authorEmail,
           license,
           view,
-          useCocoapods,
           generateExample,
           exampleName,
         };


### PR DESCRIPTION
❌ignore `useCocoapods` in generateLibraryModule

❌`npm test` succeeds at this point

seems to be missed by Stryker version 2.0.2

**bug** label is used since this change indicates functionality not covered by testing

❌DO NOT MERGE as this is known to break existing functionality

P.S. This is basically a missing object property mutation. Here is the change for the sake of clarity:

```diff
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -133,41 +133,40 @@ const generateWithOptions = ({
   const generateLibraryModule = () => {
     return fs.ensureDir(moduleName).then(() => {
       return Promise.all(templates.filter((template) => {
         if (template.platform) {
           return (platforms.indexOf(template.platform) >= 0);
         }
 
         return true;
       }).map((template) => {
         const templateArgs = {
           name: className,
           moduleName,
           packageIdentifier,
           namespace,
           platforms,
           githubAccount,
           authorName,
           authorEmail,
           license,
           view,
-          useCocoapods,
           generateExample,
           exampleName,
         };
 
         return renderTemplateIfValid(fs, moduleName, template, templateArgs);
       }));
     });
   };
 
   // This separate promise makes it easier to generate
   // multiple test or sample apps in the future.
   const generateExampleApp =
     () => {
       const exampleReactNativeInitCommand =
         `react-native init ${exampleName} --version ${exampleReactNativeVersion}`;
 
       console.info(
         `CREATE example app with the following command: ${exampleReactNativeInitCommand}`);
 
       const execOptions = { cwd: `./${moduleName}`, stdio: 'inherit' };
```