### PR TITLE
❌[WIP] EXTRA BREAKING MUTATION 1B: IGNORE `useCocoapods` in example

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -187,7 +187,6 @@ const generateWithOptions = ({
             name: className,
             moduleName,
             view,
-            useCocoapods,
             exampleName,
           };
 


### PR DESCRIPTION
❌ IGNORE `useCocoapods` in generated example

seems to be missed by Stryker version 2.0.2

**bug** label is used since this change indicates functionality not covered by testing

❌ `npm test` does not catch the mutation at this point

P.S. This is the same kind of mutation as #81: missing an object property. Here is the change for the sake of extra clarity:

```diff
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -180,21 +180,20 @@ const generateWithOptions = ({
           // Note that any exception would be properly handled since this
           // call is executed within a Promise.resolve().then() callback.
           commandSync(exampleReactNativeInitCommand, execOptions);
         })
         .then(() => {
           // Render the example template
           const templateArgs = {
             name: className,
             moduleName,
             view,
-            useCocoapods,
             exampleName,
           };
 
           return Promise.all(
             exampleTemplates.map((template) => {
               return renderTemplateIfValid(fs, moduleName, template, templateArgs);
             })
           );
         })
         .then(() => {
```

❌DO NOT MERGE as this is known to break some existing functionality

(now marked as [WIP] to avoid possible accidental merge)