### PR TITLE
❌EXTRA BREAKING MUTATION 2: IGNORE modulePrefix in options object

### DIFF
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -10,7 +10,7 @@ module.exports = (options) => {
 
   const prefix = options.prefix || '';
 
-  const modulePrefix = options.modulePrefix || DEFAULT_MODULE_PREFIX;
+  const modulePrefix = DEFAULT_MODULE_PREFIX;
 
   if (typeof name !== 'string') {
     throw new TypeError("Please write your library's name");


### PR DESCRIPTION
which is the first term in an or (`||`) expression

seems to be missed by Stryker version 2.0.2

**bug** label is used since this change indicates functionality not covered by testing

❌ `npm test` does not catch the mutation at this point

Here is the change for the sake of extra clarity:

```diff
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -10,7 +10,7 @@ module.exports = (options) => {
 
   const prefix = options.prefix || '';
 
-  const modulePrefix = options.modulePrefix || DEFAULT_MODULE_PREFIX;
+  const modulePrefix = DEFAULT_MODULE_PREFIX;
 
   if (typeof name !== 'string') {
     throw new TypeError("Please write your library's name");
```

❌DO NOT MERGE as this is known to break some existing functionality