### PR TITLE
❌ EXTRA BREAKING MUTATION 2a: IGNORE prefix in options object

### DIFF
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -8,7 +8,7 @@ const DEFAULT_MODULE_PREFIX = 'react-native';
 module.exports = (options) => {
   const name = options.name;
 
-  const prefix = options.prefix || '';
+  const prefix = '';
 
   const modulePrefix = options.modulePrefix || DEFAULT_MODULE_PREFIX;
 


### PR DESCRIPTION
which is the first term in an or (`||`) expression (similar to PR #83)

seems to be missed by Stryker version 2.0.2

**bug** label is used since this change indicates functionality not covered by testing

Here is the change for the sake of extra clarity

```diff
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -8,7 +8,7 @@ const DEFAULT_MODULE_PREFIX = 'react-native';
 module.exports = (options) => {
   const name = options.name;
 
-  const prefix = options.prefix || '';
+  const prefix = '';
 
   const modulePrefix = options.modulePrefix || DEFAULT_MODULE_PREFIX;
```

❌ `npm test` does not catch the mutation at this point

❌DO NOT MERGE as this is known to break some existing functionality