### PR TITLE
❌ EXTRA BREAKING MUTATION 3: use `name` value without paramCase call

### DIFF
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -1,4 +1,4 @@
-const paramCase = require('param-case');
+// SKIP paramCase import to let `npm test` continue with the mutated code
 
 const pascalCase = require('pascal-case');
 
@@ -27,7 +27,7 @@ module.exports = (options) => {
     options,
     moduleName
       ? {}
-      : { moduleName: `${modulePrefix}-${paramCase(name)}` },
+      : { moduleName: `${modulePrefix}-${name}` },
     className
       ? {}
       : { className: `${prefix}${pascalCase(name)}` },


### PR DESCRIPTION
(SKIP paramCase import to let `npm test` continue with the mutated code)

seems to be missed by Stryker version 2.0.2

with **bug** label is used since this change indicates functionality not covered by existing tests

❌ `npm test` does not catch the mutation at this point

Here is the actual mutation for the sake of extra clarity (removed import not shown here):

```diff
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -27,7 +27,7 @@ module.exports = (options) => {
     options,
     moduleName
       ? {}
-      : { moduleName: `${modulePrefix}-${paramCase(name)}` },
+      : { moduleName: `${modulePrefix}-${name}` },
     className
       ? {}
       : { className: `${prefix}${pascalCase(name)}` },
```

❌DO NOT MERGE as this is known to break some existing functionality