### PR TITLE
❌ EXTRA BREAKING MUTATION 2.1: moduleName = null

### DIFF
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -16,7 +16,7 @@ module.exports = (options) => {
     throw new TypeError("Please write your library's name");
   }
 
-  const moduleName = options.moduleName;
+  const moduleName = null;
 
   // OPTIONS NOT DOCUMENTED, not supported by CLI:
   const className = options.className;


### PR DESCRIPTION
(IGNORE `moduleName` in `options` object)

seems to be missed by Stryker version 2.0.2

with **bug** label since this change indicates functionality not covered by existing tests

❌ `npm test` does not catch the mutation at this point

Here is the actual mutation for the sake of extra clarity:

```diff
--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -16,7 +16,7 @@ module.exports = (options) => {
     throw new TypeError("Please write your library's name");
   }
 
-  const moduleName = options.moduleName;
+  const moduleName = null;
 
   // OPTIONS NOT DOCUMENTED, not supported by CLI:
   const className = options.className;
```

❌DO NOT MERGE as this mutation is known to break some existing functionality