### PR TITLE
Use elapsed-time package and check logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
 
 ### General status
 
+- KNOWN ISSUE IN DEPENDENCIES: unwanted and outdated `babel-runtime`, `core-js`, and `browser-process-hrtime` dependencies are pulled in by `elapsed-time@0.0.1`
 - **React Native versions supported:**
   - recommended: `0.60` (see known quirks and issues below)
   - `0.59`

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -1,3 +1,5 @@
+const elapsedTime = require('elapsed-time');
+
 const emoji = require('node-emoji');
 
 const normalizedOptions = require('./normalized-options');
@@ -29,7 +31,7 @@ module.exports = {
   func: (args, config, options) => {
     const name = args[0];
 
-    const beforeCreation = Date.now();
+    const et = elapsedTime.new().start();
 
     const platforms = (options.platforms)
       ? options.platforms.split(',') : options.platforms;
@@ -51,7 +53,7 @@ module.exports = {
     return createLibraryModule(createOptions).then(() => {
       console.log(`
 ${emoji.get('books')}  Created library module ${rootModuleName} in \`./${rootModuleName}\`.
-${emoji.get('clock9')}  It took ${Date.now() - beforeCreation}ms.
+${emoji.get('clock9')}  It took ${et.getValue()}.
 ${postCreateInstructions(createOptions)}`);
     }).catch((err) => {
       console.error(`Error while creating library module ${rootModuleName}`);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/brodybits/create-react-native-module#readme",
   "dependencies": {
     "commander": "^3.0.1",
+    "elapsed-time": "^0.0.1",
     "execa": "^2.0.4",
     "fs-extra": "^8.1.0",
     "jsonfile": "^5.0.0",

--- a/tests/with-mocks/cli/command/func/with-logging/use-cocoapods/__snapshots__/cli-command-with-logging-use-cocoapods.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/use-cocoapods/__snapshots__/cli-command-with-logging-use-cocoapods.test.js.snap
@@ -1,0 +1,566 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create alice-bobbi module with logging with --use-cocoapods for iOS 1`] = `
+Array [
+  Object {
+    "warn": Array [
+      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      identifier, it is recommended to customize the package identifier.",
+    ],
+  },
+  Object {
+    "info": Array [
+      "CREATE new React Native module with the following options:
+
+  root moduleName: react-native-alice-bobbi
+  name: alice-bobbi
+  prefix: 
+  modulePrefix: react-native
+  packageIdentifier: com.reactlibrary
+  platforms: ios
+  githubAccount: github_account
+  authorName: Your Name
+  authorEmail: yourname@email.com
+  authorEmail: yourname@email.com
+  license: MIT
+  view: false
+  useCocoapods: true
+  generateExample: false
+  exampleName: example
+  ",
+    ],
+  },
+  Object {
+    "info": Array [
+      "CREATE: Generating the React Native library module",
+    ],
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/ios/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/ios/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/README.md",
+    "theContent": "# react-native-alice-bobbi
+
+## Getting started
+
+\`$ npm install react-native-alice-bobbi --save\`
+
+### Mostly automatic installation
+
+\`$ react-native link react-native-alice-bobbi\`
+
+### Manual installation
+
+
+#### iOS
+
+1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
+2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
+3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
+4. Run your project (\`Cmd+R\`)<
+
+
+## Usage
+\`\`\`javascript
+import AliceBobbi from 'react-native-alice-bobbi';
+
+// TODO: What to do with the module?
+AliceBobbi;
+\`\`\`
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/package.json",
+    "theContent": "{
+  \\"name\\": \\"react-native-alice-bobbi\\",
+  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"TODO\\",
+  \\"main\\": \\"index.js\\",
+  \\"scripts\\": {
+    \\"test\\": \\"echo \\\\\\"Error: no test specified\\\\\\" && exit 1\\"
+  },
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  },
+  \\"keywords\\": [
+    \\"react-native\\"
+  ],
+  \\"author\\": {
+    \\"name\\": \\"Your Name\\",
+    \\"email\\": \\"yourname@email.com\\"
+  },
+  \\"license\\": \\"MIT\\",
+  \\"licenseFilename\\": \\"LICENSE\\",
+  \\"readmeFilename\\": \\"README.md\\",
+  \\"peerDependencies\\": {
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+  },
+  \\"devDependencies\\": {
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
+  }
+}
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/index.js",
+    "theContent": "import { NativeModules } from 'react-native';
+
+const { AliceBobbi } = NativeModules;
+
+export default AliceBobbi;
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "theContent": "# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "theContent": "*.pbxproj -text
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "theContent": "",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/react-native-alice-bobbi.podspec",
+    "theContent": "require \\"json\\"
+
+package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
+
+Pod::Spec.new do |s|
+  s.name         = \\"react-native-alice-bobbi\\"
+  s.version      = package[\\"version\\"]
+  s.summary      = package[\\"description\\"]
+  s.description  = <<-DESC
+                  react-native-alice-bobbi
+                   DESC
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.license      = \\"MIT\\"
+  # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
+  s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
+  s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+
+  s.source_files = \\"ios/**/*.{h,m,swift}\\"
+  s.requires_arc = true
+
+  s.dependency \\"React\\"
+	s.dependency 'AFNetworking', '~> 3.0'
+  # s.dependency \\"...\\"
+end
+
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.h",
+    "theContent": "#import <React/RCTBridgeModule.h>
+
+@interface AliceBobbi : NSObject <RCTBridgeModule>
+
+@end
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
+    "theContent": "#import \\"AliceBobbi.h\\"
+
+#import <AFNetworking/AFNetworking.h>
+
+@implementation AliceBobbi
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
+{
+    // TODO: Implement some actually useful functionality
+	AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
+	manager.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@\\"text/plain\\"];
+	[manager GET:@\\"https://httpstat.us/200\\" parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
+			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ resp: %@\\", numberArgument, stringArgument, responseObject]]);
+	} failure:^(NSURLSessionTask *operation, NSError *error) {
+			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ err: %@\\", numberArgument, stringArgument, error]]);
+	}];
+}
+
+@end
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
+    "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<Workspace
+   version = \\"1.0\\">
+   <FileRef
+      location = \\"group:AliceBobbi.xcodeproj\\">
+   </FileRef>
+</Workspace>
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj",
+    "theContent": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B3E7B58A1CC2AC0600A0062D /* AliceBobbi.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = \\"include/$(PRODUCT_NAME)\\";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libAliceBobbi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAliceBobbi.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E7B5881CC2AC0600A0062D /* AliceBobbi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AliceBobbi.h; sourceTree = \\"<group>\\"; };
+		B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AliceBobbi.m; sourceTree = \\"<group>\\"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libAliceBobbi.a */,
+			);
+			name = Products;
+			sourceTree = \\"<group>\\";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				B3E7B5881CC2AC0600A0062D /* AliceBobbi.h */,
+				B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* AliceBobbi */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"AliceBobbi\\" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AliceBobbi;
+			productName = RCTDataManager;
+			productReference = 134814201AA4EA6300B7C361 /* libAliceBobbi.a */;
+			productType = \\"com.apple.product-type.library.static\\";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"AliceBobbi\\" */;
+			compatibilityVersion = \\"Xcode 3.2\\";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = \\"\\";
+			projectRoot = \\"\\";
+			targets = (
+				58B511DA1A9E6C8500147676 /* AliceBobbi */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3E7B58A1CC2AC0600A0062D /* AliceBobbi.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"DEBUG=1\\",
+					\\"$(inherited)\\",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+				\\"$(inherited)\\",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					\\"$(SRCROOT)/../../../React/**\\",
+					\\"$(SRCROOT)/../../react-native/React/**\\",
+				);
+				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
+				OTHER_LDFLAGS = \\"-ObjC\\";
+				PRODUCT_NAME = AliceBobbi;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					\\"$(inherited)\\",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					\\"$(SRCROOT)/../../../React/**\\",
+					\\"$(SRCROOT)/../../react-native/React/**\\",
+				);
+				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
+				OTHER_LDFLAGS = \\"-ObjC\\";
+				PRODUCT_NAME = AliceBobbi;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"AliceBobbi\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"AliceBobbi\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}
+",
+  },
+  Object {
+    "log": Array [
+      "
+📚  Created library module react-native-alice-bobbi in \`./react-native-alice-bobbi\`.
+🕘  It took 12.345s.
+
+====================================================
+YOU'RE ALL SET!
+
+To build and run iOS example project, do:
+----
+cd react-native-alice-bobbi/undefined
+yarn
+cd ios
+pod install
+cd ..
+react-native run-ios
+----
+",
+    ],
+  },
+]
+`;

--- a/tests/with-mocks/cli/command/func/with-logging/use-cocoapods/cli-command-with-logging-use-cocoapods.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/use-cocoapods/cli-command-with-logging-use-cocoapods.test.js
@@ -1,0 +1,44 @@
+const func = require('../../../../../../../lib/cli-command.js').func;
+
+// special compact mocks for this test:
+const mysnap = [];
+const mockpushit = x => mysnap.push(x);
+jest.mock('elapsed-time', () => ({
+  new: () => ({
+    start: () => ({
+      getValue: () => `12.345s`
+    })
+  })
+}));
+jest.mock('fs-extra', () => ({
+  outputFile: (outputFileName, theContent) => {
+    mockpushit({ outputFileName, theContent });
+    return Promise.resolve();
+  },
+  ensureDir: (dir) => {
+    mockpushit({ ensureDir: dir });
+    return Promise.resolve();
+  },
+}));
+
+// TBD hackish mock:
+global.console = {
+  info: (...args) => {
+    mockpushit({ info: [].concat(args) });
+  },
+  log: (...args) => {
+    mockpushit({ log: [].concat(args) });
+  },
+  warn: (...args) => {
+    mockpushit({ warn: [].concat(args) });
+  },
+};
+
+test('create alice-bobbi module with logging with --use-cocoapods for iOS', () => {
+  const args = ['alice-bobbi'];
+
+  const config = 'bogus';
+
+  return func(args, config, { platforms: 'ios', useCocoapods: true })
+    .then(() => { expect(mysnap).toMatchSnapshot(); });
+});

--- a/tests/with-mocks/cli/command/func/with-logging/with-defaults/__snapshots__/cli-command-with-logging-with-defaults.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-defaults/__snapshots__/cli-command-with-logging-with-defaults.test.js.snap
@@ -1,0 +1,814 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create alice-bobbi module with logging (with defaults for Android & iOS) 1`] = `
+Array [
+  Object {
+    "warn": Array [
+      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      identifier, it is recommended to customize the package identifier.",
+    ],
+  },
+  Object {
+    "info": Array [
+      "CREATE new React Native module with the following options:
+
+  root moduleName: react-native-alice-bobbi
+  name: alice-bobbi
+  prefix: 
+  modulePrefix: react-native
+  packageIdentifier: com.reactlibrary
+  platforms: android,ios
+  githubAccount: github_account
+  authorName: Your Name
+  authorEmail: yourname@email.com
+  authorEmail: yourname@email.com
+  license: MIT
+  view: false
+  useCocoapods: false
+  generateExample: false
+  exampleName: example
+  ",
+    ],
+  },
+  Object {
+    "info": Array [
+      "CREATE: Generating the React Native library module",
+    ],
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/android/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/android/src/main/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/android/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/ios/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/ios/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/README.md",
+    "theContent": "# react-native-alice-bobbi
+
+## Getting started
+
+\`$ npm install react-native-alice-bobbi --save\`
+
+### Mostly automatic installation
+
+\`$ react-native link react-native-alice-bobbi\`
+
+### Manual installation
+
+
+#### iOS
+
+1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
+2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
+3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
+4. Run your project (\`Cmd+R\`)<
+
+#### Android
+
+1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
+  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
+  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
+2. Append the following lines to \`android/settings.gradle\`:
+  	\`\`\`
+  	include ':react-native-alice-bobbi'
+  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
+  	\`\`\`
+3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
+  	\`\`\`
+      compile project(':react-native-alice-bobbi')
+  	\`\`\`
+
+
+## Usage
+\`\`\`javascript
+import AliceBobbi from 'react-native-alice-bobbi';
+
+// TODO: What to do with the module?
+AliceBobbi;
+\`\`\`
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/package.json",
+    "theContent": "{
+  \\"name\\": \\"react-native-alice-bobbi\\",
+  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"TODO\\",
+  \\"main\\": \\"index.js\\",
+  \\"scripts\\": {
+    \\"test\\": \\"echo \\\\\\"Error: no test specified\\\\\\" && exit 1\\"
+  },
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  },
+  \\"keywords\\": [
+    \\"react-native\\"
+  ],
+  \\"author\\": {
+    \\"name\\": \\"Your Name\\",
+    \\"email\\": \\"yourname@email.com\\"
+  },
+  \\"license\\": \\"MIT\\",
+  \\"licenseFilename\\": \\"LICENSE\\",
+  \\"readmeFilename\\": \\"README.md\\",
+  \\"peerDependencies\\": {
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+  },
+  \\"devDependencies\\": {
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
+  }
+}
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/index.js",
+    "theContent": "import { NativeModules } from 'react-native';
+
+const { AliceBobbi } = NativeModules;
+
+export default AliceBobbi;
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "theContent": "# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# BUCK
+buck-out/
+\\\\.buckd/
+*.keystore
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "theContent": "*.pbxproj -text
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "theContent": "",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/android/build.gradle",
+    "theContent": "buildscript {
+    ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        // Matches recent template from React Native (0.60)
+        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'maven'
+
+// Matches values in recent template from React Native 0.59 / 0.60
+// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
+// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
+def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_TARGET_SDK_VERSION = 28
+
+android {
+  compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+  buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
+
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+    targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
+    versionCode 1
+    versionName \\"1.0\\"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}
+
+repositories {
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        // Matches recent template from React Native 0.59 / 0.60
+        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
+        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        url \\"$projectDir/../node_modules/react-native/android\\"
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation \\"com.facebook.react:react-native:\${safeExtGet('reactnativeVersion', '+')}\\"
+}
+
+def configureReactNativePom(def pom) {
+    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
+
+    pom.project {
+        name packageJson.title
+        artifactId packageJson.name
+        version = packageJson.version
+        group = \\"com.reactlibrary\\"
+        description packageJson.description
+        url packageJson.repository.baseUrl
+
+        licenses {
+            license {
+                name packageJson.license
+                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                distribution 'repo'
+            }
+        }
+
+        developers {
+            developer {
+                id packageJson.author.username
+                name packageJson.author.name
+            }
+        }
+    }
+}
+
+afterEvaluate { project ->
+
+    task androidJavadoc(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += files(android.bootClasspath)
+        classpath += files(project.getConfigurations().getByName('compile').asList())
+        include '**/*.java'
+    }
+
+    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+        classifier = 'javadoc'
+        from androidJavadoc.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.srcDirs
+        include '**/*.java'
+    }
+
+    android.libraryVariants.all { variant ->
+        def name = variant.name.capitalize()
+        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
+            from variant.javaCompile.destinationDir
+        }
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocJar
+    }
+
+    task installArchives(type: Upload) {
+        configuration = configurations.archives
+        repositories.mavenDeployer {
+            // Deploy to react-native-event-bridge/maven, ready to publish to npm
+            repository url: \\"file://\${projectDir}/../android/maven\\"
+
+            configureReactNativePom pom
+        }
+    }
+}
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/android/src/main/AndroidManifest.xml",
+    "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+          package=\\"com.reactlibrary\\">
+
+</manifest>
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
+    "theContent": "package com.reactlibrary;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Callback;
+
+public class AliceBobbiModule extends ReactContextBaseJavaModule {
+
+    private final ReactApplicationContext reactContext;
+
+    public AliceBobbiModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        this.reactContext = reactContext;
+    }
+
+    @Override
+    public String getName() {
+        return \\"AliceBobbi\\";
+    }
+
+    @ReactMethod
+    public void sampleMethod(String stringArgument, int numberArgument, Callback callback) {
+        // TODO: Implement some actually useful functionality
+        callback.invoke(\\"Received numberArgument: \\" + numberArgument + \\" stringArgument: \\" + stringArgument);
+    }
+}
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
+    "theContent": "package com.reactlibrary;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
+
+public class AliceBobbiPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Arrays.<NativeModule>asList(new AliceBobbiModule(reactContext));
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/android/README.md",
+    "theContent": "README
+======
+
+If you want to publish the lib as a maven dependency, follow these steps before publishing a new version to npm:
+
+1. Be sure to have the Android [SDK](https://developer.android.com/studio/index.html) and [NDK](https://developer.android.com/ndk/guides/index.html) installed
+2. Be sure to have a \`local.properties\` file in this folder that points to the Android SDK and NDK
+\`\`\`
+ndk.dir=/Users/{username}/Library/Android/sdk/ndk-bundle
+sdk.dir=/Users/{username}/Library/Android/sdk
+\`\`\`
+3. Delete the \`maven\` folder
+4. Run \`sudo ./gradlew installArchives\`
+5. Verify that latest set of generated files is in the maven folder with the correct version number
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/react-native-alice-bobbi.podspec",
+    "theContent": "require \\"json\\"
+
+package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
+
+Pod::Spec.new do |s|
+  s.name         = \\"react-native-alice-bobbi\\"
+  s.version      = package[\\"version\\"]
+  s.summary      = package[\\"description\\"]
+  s.description  = <<-DESC
+                  react-native-alice-bobbi
+                   DESC
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.license      = \\"MIT\\"
+  # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
+  s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
+  s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+
+  s.source_files = \\"ios/**/*.{h,m,swift}\\"
+  s.requires_arc = true
+
+  s.dependency \\"React\\"
+	
+  # s.dependency \\"...\\"
+end
+
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.h",
+    "theContent": "#import <React/RCTBridgeModule.h>
+
+@interface AliceBobbi : NSObject <RCTBridgeModule>
+
+@end
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
+    "theContent": "#import \\"AliceBobbi.h\\"
+
+
+@implementation AliceBobbi
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
+{
+    // TODO: Implement some actually useful functionality
+	callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@\\", numberArgument, stringArgument]]);
+}
+
+@end
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
+    "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<Workspace
+   version = \\"1.0\\">
+   <FileRef
+      location = \\"group:AliceBobbi.xcodeproj\\">
+   </FileRef>
+</Workspace>
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj",
+    "theContent": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B3E7B58A1CC2AC0600A0062D /* AliceBobbi.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = \\"include/$(PRODUCT_NAME)\\";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libAliceBobbi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAliceBobbi.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E7B5881CC2AC0600A0062D /* AliceBobbi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AliceBobbi.h; sourceTree = \\"<group>\\"; };
+		B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AliceBobbi.m; sourceTree = \\"<group>\\"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libAliceBobbi.a */,
+			);
+			name = Products;
+			sourceTree = \\"<group>\\";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				B3E7B5881CC2AC0600A0062D /* AliceBobbi.h */,
+				B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* AliceBobbi */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"AliceBobbi\\" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AliceBobbi;
+			productName = RCTDataManager;
+			productReference = 134814201AA4EA6300B7C361 /* libAliceBobbi.a */;
+			productType = \\"com.apple.product-type.library.static\\";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"AliceBobbi\\" */;
+			compatibilityVersion = \\"Xcode 3.2\\";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = \\"\\";
+			projectRoot = \\"\\";
+			targets = (
+				58B511DA1A9E6C8500147676 /* AliceBobbi */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3E7B58A1CC2AC0600A0062D /* AliceBobbi.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"DEBUG=1\\",
+					\\"$(inherited)\\",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+				\\"$(inherited)\\",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					\\"$(SRCROOT)/../../../React/**\\",
+					\\"$(SRCROOT)/../../react-native/React/**\\",
+				);
+				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
+				OTHER_LDFLAGS = \\"-ObjC\\";
+				PRODUCT_NAME = AliceBobbi;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					\\"$(inherited)\\",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					\\"$(SRCROOT)/../../../React/**\\",
+					\\"$(SRCROOT)/../../react-native/React/**\\",
+				);
+				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
+				OTHER_LDFLAGS = \\"-ObjC\\";
+				PRODUCT_NAME = AliceBobbi;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"AliceBobbi\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"AliceBobbi\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}
+",
+  },
+  Object {
+    "log": Array [
+      "
+📚  Created library module react-native-alice-bobbi in \`./react-native-alice-bobbi\`.
+🕘  It took 12.345s.
+
+====================================================
+YOU'RE ALL SET!
+
+To build and run iOS example project, do:
+----
+cd react-native-alice-bobbi/undefined
+yarn
+react-native run-ios
+----
+",
+    ],
+  },
+]
+`;

--- a/tests/with-mocks/cli/command/func/with-logging/with-defaults/cli-command-with-logging-with-defaults.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/with-defaults/cli-command-with-logging-with-defaults.test.js
@@ -1,0 +1,44 @@
+const func = require('../../../../../../../lib/cli-command.js').func;
+
+// special compact mocks for this test:
+const mysnap = [];
+const mockpushit = x => mysnap.push(x);
+jest.mock('elapsed-time', () => ({
+  new: () => ({
+    start: () => ({
+      getValue: () => `12.345s`
+    })
+  })
+}));
+jest.mock('fs-extra', () => ({
+  outputFile: (outputFileName, theContent) => {
+    mockpushit({ outputFileName, theContent });
+    return Promise.resolve();
+  },
+  ensureDir: (dir) => {
+    mockpushit({ ensureDir: dir });
+    return Promise.resolve();
+  },
+}));
+
+// TBD hackish mock:
+global.console = {
+  info: (...args) => {
+    mockpushit({ info: [].concat(args) });
+  },
+  log: (...args) => {
+    mockpushit({ log: [].concat(args) });
+  },
+  warn: (...args) => {
+    mockpushit({ warn: [].concat(args) });
+  },
+};
+
+test('create alice-bobbi module with logging (with defaults for Android & iOS)', () => {
+  const args = ['alice-bobbi'];
+
+  const config = 'bogus';
+
+  return func(args, config, {})
+    .then(() => { expect(mysnap).toMatchSnapshot(); });
+});

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create alice-bobbi module with logging, with fs error (with defaults for Android & iOS) 1`] = `
+Array [
+  Object {
+    "warn": Array [
+      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      identifier, it is recommended to customize the package identifier.",
+    ],
+  },
+  Object {
+    "info": Array [
+      "CREATE new React Native module with the following options:
+
+  root moduleName: react-native-alice-bobbi
+  name: alice-bobbi
+  prefix: 
+  modulePrefix: react-native
+  packageIdentifier: com.reactlibrary
+  platforms: android,ios
+  githubAccount: github_account
+  authorName: Your Name
+  authorEmail: yourname@email.com
+  authorEmail: yourname@email.com
+  license: MIT
+  view: false
+  useCocoapods: false
+  generateExample: false
+  exampleName: example
+  ",
+    ],
+  },
+  Object {
+    "info": Array [
+      "CREATE: Generating the React Native library module",
+    ],
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi",
+  },
+  Object {
+    "error": Array [
+      "Error while creating library module react-native-alice-bobbi",
+    ],
+  },
+  Object {
+    "error": Array [
+      "Error: ENOPERM not permitted
+    at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:16:27)
+    at ensureDir (.../lib/lib.js:134:15)
+    at generateLibraryModule (.../lib/lib.js:227:10)
+    at generateWithOptions (.../lib/lib.js:244:10)
+    at createLibraryModule (.../lib/cli-command.js:...
+    at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:64:10)
+    ",
+    ],
+  },
+]
+`;

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js
@@ -1,0 +1,66 @@
+const func = require('../../../../../../../lib/cli-command.js').func;
+
+// special compact mocks for this test:
+const mysnap = [];
+const mockpushit = x => mysnap.push(x);
+jest.mock('elapsed-time', () => ({
+  new: () => ({
+    start: () => ({
+      getValue: () => `12.345s`
+    })
+  })
+}));
+jest.mock('fs-extra', () => ({
+  ensureDir: (dir) => {
+    mockpushit({ ensureDir: dir });
+    return Promise.reject(new Error(`ENOPERM not permitted`));
+  },
+  outputFile: (outputFileName, theContent) => {
+    // NOT EXPECTED:
+    mockpushit({ outputFileName, theContent });
+    return Promise.reject(new Error(`ENOPERM not permitted`));
+  },
+}));
+
+// TBD hackish mock:
+global.console = {
+  info: (...args) => {
+    mockpushit({ info: [].concat(args) });
+  },
+  log: (...args) => {
+    mockpushit({ log: [].concat(args) });
+  },
+  warn: (...args) => {
+    mockpushit({ warn: [].concat(args) });
+  },
+  error: (first, ...rest) => {
+    mockpushit({
+      error: [].concat(
+        [].concat(
+          first
+            // Check trace with relative path
+            // THANKS for guidance:
+            // * https://stackoverflow.com/questions/1144783/how-to-replace-all-occurrences-of-a-string/1145525#1145525
+            // * https://github.com/tunnckoCore/clean-stacktrace-relative-paths/blob/v1.0.4/index.js#L59
+            .split(process.cwd()).join('...')
+            // IGNORE test-dependant trace info
+            .split(/at.*JestTest/)[0]
+            // IGNORE line number in cli-command.js
+            // in order to avoid sensitivity to mutation testing
+            // (miss potentially surviving mutants)
+            .replace(/cli-command.js:.*/, 'cli-command.js:...')
+        ),
+        rest
+      )
+    });
+  },
+};
+
+test('create alice-bobbi module with logging, with fs error (with defaults for Android & iOS)', () => {
+  const args = ['alice-bobbi'];
+
+  const config = 'bogus';
+
+  return func(args, config, {})
+    .then(() => { expect(mysnap).toMatchSnapshot(); });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,6 +742,13 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
+babel-runtime@^5.8.20:
+  version "5.8.38"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
+  integrity sha1-HAsC62MxL18If/IEUIJ7QlydTBk=
+  dependencies:
+    core-js "^1.0.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -1045,6 +1052,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1256,6 +1268,14 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+elapsed-time@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/elapsed-time/-/elapsed-time-0.0.1.tgz#f91e333a25ce1201ed81c233f8a9ee40d427cd86"
+  integrity sha1-+R4zOiXOEgHtgcIz+KnuQNQnzYY=
+  dependencies:
+    babel-runtime "^5.8.20"
+    browser-process-hrtime "^0.1.2"
 
 emoji-regex@^7.0.1:
   version "7.0.3"


### PR DESCRIPTION
* Use `elapsed-time` package to get elapsed time for logging, which can be mocked to get deterministic log output for unit testing - has a known issue in dependencies which is described in README.md
* unit test CLI command func with defaults (adds coverage for CLI command function log output)
* unit test CLI command func with error logging (adds a little more coverage for CLI command function log output)
* test cli-command.js logging, with `--use-cocoapods`

These changes increase unit test coverage of `lib/cli-command.js` to almost 100%.

TODO items to be resolved:

* [ ] unwanted and outdated `babel-runtime`, `core-js`, and `browser-process-hrtime` dependencies are pulled in by elapsed-time@0.0.1
* [ ] fix post-create instructions for example project (see issue #101)

Added **bug** label since the missing code coverage should be resolved if possible.