### PR TITLE
[WIP] Android build.gradle updates from 0.61-stable

### DIFF
--- a/templates/android.js
+++ b/templates/android.js
@@ -10,18 +10,17 @@ module.exports = platform => [{
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath("com.android.tools.build:gradle:$\{safeExtGet('gradlePluginVersion', '3.4.1')\}")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath("com.android.tools.build:gradle:$\{safeExtGet('gradlePluginVersion', '3.4.2')\}")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -45,9 +44,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url "$projectDir/../node_modules/react-native/android"
     }
     mavenCentral()

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -209,18 +209,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -244,9 +243,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -214,18 +214,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -249,9 +248,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -214,18 +214,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -249,9 +248,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -171,18 +171,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -206,9 +205,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -209,18 +209,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -244,9 +243,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -214,18 +214,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -249,9 +248,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -214,18 +214,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -249,9 +248,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -214,18 +214,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -249,9 +248,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -214,18 +214,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -249,9 +248,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -209,18 +209,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -244,9 +243,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -171,18 +171,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -206,9 +205,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -209,18 +209,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -244,9 +243,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -209,18 +209,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -244,9 +243,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -209,18 +209,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -244,9 +243,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -209,18 +209,17 @@ buildscript {
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -244,9 +243,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -213,18 +213,17 @@ buck-out/
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -248,9 +247,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -336,18 +336,17 @@ buck-out/
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -371,9 +370,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -278,18 +278,17 @@ buck-out/
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -313,9 +312,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -278,18 +278,17 @@ buck-out/
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -313,9 +312,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -278,18 +278,17 @@ buck-out/
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -313,9 +312,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -272,18 +272,17 @@ buck-out/
     }
 
     dependencies {
-        // Matches recent template from React Native (0.60)
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
-        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+        // Matches recent template from React Native (0.61)
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L15
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.2')}\\")
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-// Matches values in recent template from React Native 0.59 / 0.60
-// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
-// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+// Matches values in recent template from React Native 0.59 / 0.60 / 0.61
+// https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L5-L8
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
 def DEFAULT_MIN_SDK_VERSION = 16
@@ -307,9 +306,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches recent template from React Native 0.59 / 0.60
-        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
-        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        // Matches recent template from React Native 0.59 / 0.60 / 0.61
+        // https://github.com/facebook/react-native/blob/0.61-stable/template/android/build.gradle#L27
         url \\"$projectDir/../node_modules/react-native/android\\"
     }
     mavenCentral()


### PR DESCRIPTION
now using Android Gradle plugin version 3.4.2, presumably from Android Studio 3.4.2

and tested on React Native versions 0.59, 0.60, and 0.61-rc

/cc @SaeedZhiany

P.S. adding reference to #93 (React Native 0.61 support)