### PR TITLE
Fix crash when no args passed in

### DIFF
--- a/lib/cli-program.js
+++ b/lib/cli-program.js
@@ -22,11 +22,8 @@ program
     opt.default
   ));
 
-program.parse(process.argv);
-
-// TBD non-functional error handling code
-// FUTURE TODO: handle missing argument error in the right place
-// (see issue #48)
-// if (!program.args.length) {
-//   program.help();
-// }
+const args = process.argv;
+if (args.length === 2) {
+  args.push('--help');
+}
+program.parse(args);

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bin/cli.js with no arguments returns expected output 1`] = `
+"Usage: cli [options] <name>
+
+creates a React Native library module for one or more platforms
+
+Options:
+  -V, --version                                               output the version number
+  --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
+  --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
+  --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
+  --package-identifier [packageIdentifier]                    (Android only!) The package name for the Android module (default: \\"com.reactlibrary\\")
+  --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
+  --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")
+  --author-name [authorName]                                  The author's name (default: \\"Your Name\\")
+  --author-email [authorEmail]                                The author's email (default: \\"yourname@email.com\\")
+  --license [license]                                         The license type (default: \\"MIT\\")
+  --view                                                      Generate the module as a very simple native view component
+  --use-cocoapods                                             Generate a library with a sample podspec and third party pod usage example
+  --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
+  --example-name [exampleName]                                Name for the example project (default: \\"example\\")
+  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")
+  -h, --help                                                  output usage information"
+`;

--- a/tests/integration/cli/noargs/cli-noargs.test.js
+++ b/tests/integration/cli/noargs/cli-noargs.test.js
@@ -1,0 +1,13 @@
+const execa = require('execa');
+const path = require('path');
+
+test('bin/cli.js with no arguments returns expected output', () => {
+  // Test fix for issue #48
+  return Promise.resolve(
+    execa.command(`node ${path.resolve('bin/cli.js')}`)
+  ).then(
+    ({ stdout }) => {
+      expect(stdout).toMatchSnapshot();
+    }
+  );
+});


### PR DESCRIPTION
Fix #48 .

Root cause: The `commander` module seems to try to detect this problem and push the `--help` argument on `process.argv`.  Unfortunately, that push is silently ignored, leading to the ugly error message issue.

Fix: Create our own args array, detect this condition, push `--help` onto the arg array, and then proceed with `program.parse()`.

Snapshot test also added.