### PR TITLE
unit test of missing CLI args using mocks

### DIFF
--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mocked cli-program.js shows help in case of missing args 1`] = `
+Array [
+  Object {
+    "notify": Object {},
+  },
+  Object {
+    "version": "x",
+  },
+  Object {
+    "usage": "[options] <name>",
+  },
+  Object {
+    "description": "creates a React Native library module for one or more platforms",
+  },
+  Object {
+    "action": Object {},
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--prefix [prefix]",
+        "The prefix for the library module",
+        [Function],
+        "",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--module-name [moduleName]",
+        "The module library package name to be used in package.json. Default: react-native-(name in param-case)",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--module-prefix [modulePrefix]",
+        "The module prefix for the library module, ignored if --module-name is specified",
+        [Function],
+        "react-native",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--package-identifier [packageIdentifier]",
+        "(Android only!) The package name for the Android module",
+        [Function],
+        "com.reactlibrary",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--platforms <platforms>",
+        "Platforms the library module will be created for - comma separated",
+        [Function],
+        "ios,android",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--github-account [githubAccount]",
+        "The github account where the library module is hosted",
+        [Function],
+        "github_account",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--author-name [authorName]",
+        "The author's name",
+        [Function],
+        "Your Name",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--author-email [authorEmail]",
+        "The author's email",
+        [Function],
+        "yourname@email.com",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--license [license]",
+        "The license type",
+        [Function],
+        "MIT",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--view",
+        "Generate the module as a very simple native view component",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--use-cocoapods",
+        "Generate a library with a sample podspec and third party pod usage example",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--generate-example",
+        "Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--example-name [exampleName]",
+        "Name for the example project",
+        [Function],
+        "example",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--example-react-native-version [exampleReactNativeVersion]",
+        "React Native version for the generated example project",
+        [Function],
+        "react-native@0.59",
+      ],
+    },
+  },
+  Object {
+    "parse": Object {
+      "argv": Array [
+        "node",
+        "./bin/cli.js",
+        "--help",
+      ],
+    },
+  },
+]
+`;

--- a/tests/with-mocks/cli/program/with-missing-args/cli-program-with-missing-args.test.js
+++ b/tests/with-mocks/cli/program/with-missing-args/cli-program-with-missing-args.test.js
@@ -1,0 +1,57 @@
+// special compact mocks for this test:
+const mysnap = [];
+const mockpushit = x => mysnap.push(x);
+jest.mock('update-notifier', () => ({ pkg }) => {
+  // only check a limited number of fields in pkg
+  expect(pkg.name).toBeDefined();
+  expect(pkg.version).toBeDefined();
+  return { notify: () => mockpushit({ notify: {} }) };
+});
+const mockCommander = {
+  args: ['test-package'],
+  version: (version) => {
+    // actual value of version not expected to be stable
+    expect(version).toBeDefined();
+    mockpushit({ version: 'x' });
+    return mockCommander;
+  },
+  usage: (usage) => {
+    mockpushit({ usage });
+    return mockCommander;
+  },
+  description: (description) => {
+    mockpushit({ description });
+    return mockCommander;
+  },
+  action: (_) => {
+    mockpushit({ action: {} });
+    return mockCommander;
+  },
+  option: (...args) => {
+    mockpushit({ option: { args } });
+    return mockCommander;
+  },
+  parse: (argv) => {
+    // ensure that cli-program.js adds the `--help` option:
+    expect(argv.length).toBe(3);
+    expect(argv[2]).toBe('--help');
+    mockpushit({ parse: { argv } });
+  },
+};
+jest.mock('commander', () => mockCommander);
+
+// TBD hackish mock(s) - testing with missing CLI arguments:
+process.argv = ['node', './bin/cli.js'];
+
+test('mocked cli-program.js shows help in case of missing args', () => {
+  // FUTURE TBD define this kind of a relative path near the beginning
+  // of the test script
+  require('../../../../../lib/cli-program.js');
+
+  // Using a 1 ms timer to wait for the
+  // CLI program func to finish.
+  // FUTURE TBD this looks like a bad smell
+  // that should be resolved someday.
+  return new Promise((resolve) => setTimeout(resolve, 1))
+    .then(() => { expect(mysnap).toMatchSnapshot(); });
+});


### PR DESCRIPTION
as a followup to PR #109 ..

rationale: I like to cover as much as possible by unit testing

Primary purpose of the spawned integration tests is to cover anything that cannot be covered by in-process unit testing.

I would like to merge this proposal within the next 12-24 hours, before making the next patch release.

/cc @dlowder-salesforce