### PR TITLE
[...] improve code to check minimum CLI argument count

### DIFF
--- a/lib/cli-program.js
+++ b/lib/cli-program.js
@@ -4,6 +4,8 @@ const updateNotifier = require('update-notifier');
 const command = require('./cli-command');
 const pkg = require('./../package.json');
 
+const MIN_CLI_ARGS_LENGTH = 3;
+
 updateNotifier({ pkg }).notify();
 
 program
@@ -22,8 +24,12 @@ program
     opt.default
   ));
 
-const args = process.argv;
-if (args.length === 2) {
-  args.push('--help');
-}
+const args =
+  [].concat(
+    process.argv,
+    (process.argv.length < MIN_CLI_ARGS_LENGTH)
+      ? '--help'
+      : []
+  );
+
 program.parse(args);


### PR DESCRIPTION
* use relative comparison operator instead of absolute `===` operator
* use a constant instead of hard-coded numeric value
* use `[].concat` call to avoid overwriting some incoming data
* make the code a little more functional

as a followup to PR #109;

passes all tests, passes new unit test proposed in PR #111.

raising as a DRAFT PR, with feedback requested

/cc @dlowder-salesforce @dsyne