### PR TITLE
CLI create integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ npm-debug.log
 .stryker-tmp
 reports
 stryker.log
+
+# CLI create integration test output to be ignored
+react-native-integration-*

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-node": "^9.2.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "recursive-readdir": "^2.2.2"
   }
 }

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -1,0 +1,719 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI creates correct view module package artifacts on file system using \`--view\` option (and no other options) 1`] = `
+Array [
+  Object {
+    "contents": "*.pbxproj -text
+",
+    "name": "react-native-integration-view-test-package/.gitattributes",
+  },
+  Object {
+    "contents": "# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# BUCK
+buck-out/
+\\\\.buckd/
+*.keystore
+",
+    "name": "react-native-integration-view-test-package/.gitignore",
+  },
+  Object {
+    "contents": "",
+    "name": "react-native-integration-view-test-package/.npmignore",
+  },
+  Object {
+    "contents": "# react-native-integration-view-test-package
+
+## Getting started
+
+\`$ npm install react-native-integration-view-test-package --save\`
+
+### Mostly automatic installation
+
+\`$ react-native link react-native-integration-view-test-package\`
+
+### Manual installation
+
+
+#### iOS
+
+1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
+2. Go to \`node_modules\` ➜ \`react-native-integration-view-test-package\` and add \`IntegrationViewTestPackage.xcodeproj\`
+3. In XCode, in the project navigator, select your project. Add \`libIntegrationViewTestPackage.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
+4. Run your project (\`Cmd+R\`)<
+
+#### Android
+
+1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
+  - Add \`import com.reactlibrary.IntegrationViewTestPackagePackage;\` to the imports at the top of the file
+  - Add \`new IntegrationViewTestPackagePackage()\` to the list returned by the \`getPackages()\` method
+2. Append the following lines to \`android/settings.gradle\`:
+  	\`\`\`
+  	include ':react-native-integration-view-test-package'
+  	project(':react-native-integration-view-test-package').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-integration-view-test-package/android')
+  	\`\`\`
+3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
+  	\`\`\`
+      compile project(':react-native-integration-view-test-package')
+  	\`\`\`
+
+
+## Usage
+\`\`\`javascript
+import IntegrationViewTestPackage from 'react-native-integration-view-test-package';
+
+// TODO: What to do with the module?
+IntegrationViewTestPackage;
+\`\`\`
+",
+    "name": "react-native-integration-view-test-package/README.md",
+  },
+  Object {
+    "contents": "README
+======
+
+If you want to publish the lib as a maven dependency, follow these steps before publishing a new version to npm:
+
+1. Be sure to have the Android [SDK](https://developer.android.com/studio/index.html) and [NDK](https://developer.android.com/ndk/guides/index.html) installed
+2. Be sure to have a \`local.properties\` file in this folder that points to the Android SDK and NDK
+\`\`\`
+ndk.dir=/Users/{username}/Library/Android/sdk/ndk-bundle
+sdk.dir=/Users/{username}/Library/Android/sdk
+\`\`\`
+3. Delete the \`maven\` folder
+4. Run \`sudo ./gradlew installArchives\`
+5. Verify that latest set of generated files is in the maven folder with the correct version number
+",
+    "name": "react-native-integration-view-test-package/android/README.md",
+  },
+  Object {
+    "contents": "buildscript {
+    ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        // Matches recent template from React Native (0.60)
+        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'maven'
+
+// Matches values in recent template from React Native 0.59 / 0.60
+// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
+// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
+def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_TARGET_SDK_VERSION = 28
+
+android {
+  compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+  buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
+
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+    targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
+    versionCode 1
+    versionName \\"1.0\\"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}
+
+repositories {
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        // Matches recent template from React Native 0.59 / 0.60
+        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
+        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        url \\"$projectDir/../node_modules/react-native/android\\"
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation \\"com.facebook.react:react-native:\${safeExtGet('reactnativeVersion', '+')}\\"
+}
+
+def configureReactNativePom(def pom) {
+    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
+
+    pom.project {
+        name packageJson.title
+        artifactId packageJson.name
+        version = packageJson.version
+        group = \\"com.reactlibrary\\"
+        description packageJson.description
+        url packageJson.repository.baseUrl
+
+        licenses {
+            license {
+                name packageJson.license
+                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                distribution 'repo'
+            }
+        }
+
+        developers {
+            developer {
+                id packageJson.author.username
+                name packageJson.author.name
+            }
+        }
+    }
+}
+
+afterEvaluate { project ->
+
+    task androidJavadoc(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += files(android.bootClasspath)
+        classpath += files(project.getConfigurations().getByName('compile').asList())
+        include '**/*.java'
+    }
+
+    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+        classifier = 'javadoc'
+        from androidJavadoc.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.srcDirs
+        include '**/*.java'
+    }
+
+    android.libraryVariants.all { variant ->
+        def name = variant.name.capitalize()
+        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
+            from variant.javaCompile.destinationDir
+        }
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocJar
+    }
+
+    task installArchives(type: Upload) {
+        configuration = configurations.archives
+        repositories.mavenDeployer {
+            // Deploy to react-native-event-bridge/maven, ready to publish to npm
+            repository url: \\"file://\${projectDir}/../android/maven\\"
+
+            configureReactNativePom pom
+        }
+    }
+}
+",
+    "name": "react-native-integration-view-test-package/android/build.gradle",
+  },
+  Object {
+    "contents": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+          package=\\"com.reactlibrary\\">
+
+</manifest>
+",
+    "name": "react-native-integration-view-test-package/android/src/main/AndroidManifest.xml",
+  },
+  Object {
+    "contents": "package com.reactlibrary;
+
+import android.view.View;
+
+// AppCompatCheckBox import for React Native pre-0.60:
+import android.support.v7.widget.AppCompatCheckBox;
+// AppCompatCheckBox import for React Native 0.60(+):
+// import androidx.appcompat.widget.AppCompatCheckBox;
+
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+public class IntegrationViewTestPackageManager extends SimpleViewManager<View> {
+
+    public static final String REACT_CLASS = \\"IntegrationViewTestPackage\\";
+
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
+
+    @Override
+    public View createViewInstance(ThemedReactContext c) {
+        // TODO: Implement some actually useful functionality
+        AppCompatCheckBox cb = new AppCompatCheckBox(c);
+        cb.setChecked(true);
+        return cb;
+    }
+}
+",
+    "name": "react-native-integration-view-test-package/android/src/main/java/com/reactlibrary/IntegrationViewTestPackageManager.java",
+  },
+  Object {
+    "contents": "package com.reactlibrary;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
+
+public class IntegrationViewTestPackagePackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Arrays.<ViewManager>asList(new IntegrationViewTestPackageManager());
+    }
+}
+",
+    "name": "react-native-integration-view-test-package/android/src/main/java/com/reactlibrary/IntegrationViewTestPackagePackage.java",
+  },
+  Object {
+    "contents": "import { requireNativeComponent } from 'react-native';
+
+const IntegrationViewTestPackage = requireNativeComponent('IntegrationViewTestPackage', null);
+
+export default IntegrationViewTestPackage;
+",
+    "name": "react-native-integration-view-test-package/index.js",
+  },
+  Object {
+    "contents": "#import <React/RCTViewManager.h>
+
+@interface IntegrationViewTestPackage : RCTViewManager
+
+@end
+",
+    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.h",
+  },
+  Object {
+    "contents": "#import \\"IntegrationViewTestPackage.h\\"
+
+@implementation IntegrationViewTestPackage
+
+RCT_EXPORT_MODULE()
+
+- (UIView *)view
+{
+    // TODO: Implement some actually useful functionality
+    UILabel * label = [[UILabel alloc] init];
+    [label setTextColor:[UIColor redColor]];
+    [label setText: @\\"*****\\"];
+    [label sizeToFit];
+    UIView * wrapper = [[UIView alloc] init];
+    [wrapper addSubview:label];
+    return wrapper;
+}
+
+@end
+",
+    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.m",
+  },
+  Object {
+    "contents": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B3E7B58A1CC2AC0600A0062D /* IntegrationViewTestPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* IntegrationViewTestPackage.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = \\"include/$(PRODUCT_NAME)\\";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libIntegrationViewTestPackage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libIntegrationViewTestPackage.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E7B5881CC2AC0600A0062D /* IntegrationViewTestPackage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntegrationViewTestPackage.h; sourceTree = \\"<group>\\"; };
+		B3E7B5891CC2AC0600A0062D /* IntegrationViewTestPackage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntegrationViewTestPackage.m; sourceTree = \\"<group>\\"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libIntegrationViewTestPackage.a */,
+			);
+			name = Products;
+			sourceTree = \\"<group>\\";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				B3E7B5881CC2AC0600A0062D /* IntegrationViewTestPackage.h */,
+				B3E7B5891CC2AC0600A0062D /* IntegrationViewTestPackage.m */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* IntegrationViewTestPackage */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"IntegrationViewTestPackage\\" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IntegrationViewTestPackage;
+			productName = RCTDataManager;
+			productReference = 134814201AA4EA6300B7C361 /* libIntegrationViewTestPackage.a */;
+			productType = \\"com.apple.product-type.library.static\\";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"IntegrationViewTestPackage\\" */;
+			compatibilityVersion = \\"Xcode 3.2\\";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = \\"\\";
+			projectRoot = \\"\\";
+			targets = (
+				58B511DA1A9E6C8500147676 /* IntegrationViewTestPackage */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3E7B58A1CC2AC0600A0062D /* IntegrationViewTestPackage.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"DEBUG=1\\",
+					\\"$(inherited)\\",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+				\\"$(inherited)\\",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					\\"$(SRCROOT)/../../../React/**\\",
+					\\"$(SRCROOT)/../../react-native/React/**\\",
+				);
+				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
+				OTHER_LDFLAGS = \\"-ObjC\\";
+				PRODUCT_NAME = IntegrationViewTestPackage;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					\\"$(inherited)\\",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					\\"$(SRCROOT)/../../../React/**\\",
+					\\"$(SRCROOT)/../../react-native/React/**\\",
+				);
+				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
+				OTHER_LDFLAGS = \\"-ObjC\\";
+				PRODUCT_NAME = IntegrationViewTestPackage;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"IntegrationViewTestPackage\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"IntegrationViewTestPackage\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}
+",
+    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.xcodeproj/project.pbxproj",
+  },
+  Object {
+    "contents": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<Workspace
+   version = \\"1.0\\">
+   <FileRef
+      location = \\"group:IntegrationViewTestPackage.xcodeproj\\">
+   </FileRef>
+</Workspace>
+",
+    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.xcworkspace/contents.xcworkspacedata",
+  },
+  Object {
+    "contents": "{
+  \\"name\\": \\"react-native-integration-view-test-package\\",
+  \\"title\\": \\"React Native Integration View Test Package\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"TODO\\",
+  \\"main\\": \\"index.js\\",
+  \\"scripts\\": {
+    \\"test\\": \\"echo \\\\\\"Error: no test specified\\\\\\" && exit 1\\"
+  },
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"git+https://github.com/github_account/react-native-integration-view-test-package.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-integration-view-test-package\\"
+  },
+  \\"keywords\\": [
+    \\"react-native\\"
+  ],
+  \\"author\\": {
+    \\"name\\": \\"Your Name\\",
+    \\"email\\": \\"yourname@email.com\\"
+  },
+  \\"license\\": \\"MIT\\",
+  \\"licenseFilename\\": \\"LICENSE\\",
+  \\"readmeFilename\\": \\"README.md\\",
+  \\"peerDependencies\\": {
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+  },
+  \\"devDependencies\\": {
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
+  }
+}
+",
+    "name": "react-native-integration-view-test-package/package.json",
+  },
+  Object {
+    "contents": "require \\"json\\"
+
+package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
+
+Pod::Spec.new do |s|
+  s.name         = \\"react-native-integration-view-test-package\\"
+  s.version      = package[\\"version\\"]
+  s.summary      = package[\\"description\\"]
+  s.description  = <<-DESC
+                  react-native-integration-view-test-package
+                   DESC
+  s.homepage     = \\"https://github.com/github_account/react-native-integration-view-test-package\\"
+  s.license      = \\"MIT\\"
+  # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
+  s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
+  s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-integration-view-test-package.git\\", :tag => \\"#{s.version}\\" }
+
+  s.source_files = \\"ios/**/*.{h,m,swift}\\"
+  s.requires_arc = true
+
+  s.dependency \\"React\\"
+	
+  # s.dependency \\"...\\"
+end
+
+",
+    "name": "react-native-integration-view-test-package/react-native-integration-view-test-package.podspec",
+  },
+]
+`;

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -3,12 +3,13 @@
 exports[`CLI creates correct view module package artifacts on file system using \`--view\` option (and no other options) 1`] = `
 Array [
   Object {
-    "contents": "*.pbxproj -text
-",
     "name": "react-native-integration-view-test-package/.gitattributes",
+    "theContent": "*.pbxproj -text
+",
   },
   Object {
-    "contents": "# OSX
+    "name": "react-native-integration-view-test-package/.gitignore",
+    "theContent": "# OSX
 #
 .DS_Store
 
@@ -51,14 +52,14 @@ buck-out/
 \\\\.buckd/
 *.keystore
 ",
-    "name": "react-native-integration-view-test-package/.gitignore",
   },
   Object {
-    "contents": "",
     "name": "react-native-integration-view-test-package/.npmignore",
+    "theContent": "",
   },
   Object {
-    "contents": "# react-native-integration-view-test-package
+    "name": "react-native-integration-view-test-package/README.md",
+    "theContent": "# react-native-integration-view-test-package
 
 ## Getting started
 
@@ -102,10 +103,10 @@ import IntegrationViewTestPackage from 'react-native-integration-view-test-packa
 IntegrationViewTestPackage;
 \`\`\`
 ",
-    "name": "react-native-integration-view-test-package/README.md",
   },
   Object {
-    "contents": "README
+    "name": "react-native-integration-view-test-package/android/README.md",
+    "theContent": "README
 ======
 
 If you want to publish the lib as a maven dependency, follow these steps before publishing a new version to npm:
@@ -120,10 +121,10 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 4. Run \`sudo ./gradlew installArchives\`
 5. Verify that latest set of generated files is in the maven folder with the correct version number
 ",
-    "name": "react-native-integration-view-test-package/android/README.md",
   },
   Object {
-    "contents": "buildscript {
+    "name": "react-native-integration-view-test-package/android/build.gradle",
+    "theContent": "buildscript {
     ext.safeExtGet = {prop, fallback ->
         rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
     }
@@ -251,18 +252,18 @@ afterEvaluate { project ->
     }
 }
 ",
-    "name": "react-native-integration-view-test-package/android/build.gradle",
   },
   Object {
-    "contents": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+    "name": "react-native-integration-view-test-package/android/src/main/AndroidManifest.xml",
+    "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
           package=\\"com.reactlibrary\\">
 
 </manifest>
 ",
-    "name": "react-native-integration-view-test-package/android/src/main/AndroidManifest.xml",
   },
   Object {
-    "contents": "package com.reactlibrary;
+    "name": "react-native-integration-view-test-package/android/src/main/java/com/reactlibrary/IntegrationViewTestPackageManager.java",
+    "theContent": "package com.reactlibrary;
 
 import android.view.View;
 
@@ -292,10 +293,10 @@ public class IntegrationViewTestPackageManager extends SimpleViewManager<View> {
     }
 }
 ",
-    "name": "react-native-integration-view-test-package/android/src/main/java/com/reactlibrary/IntegrationViewTestPackageManager.java",
   },
   Object {
-    "contents": "package com.reactlibrary;
+    "name": "react-native-integration-view-test-package/android/src/main/java/com/reactlibrary/IntegrationViewTestPackagePackage.java",
+    "theContent": "package com.reactlibrary;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -319,28 +320,28 @@ public class IntegrationViewTestPackagePackage implements ReactPackage {
     }
 }
 ",
-    "name": "react-native-integration-view-test-package/android/src/main/java/com/reactlibrary/IntegrationViewTestPackagePackage.java",
   },
   Object {
-    "contents": "import { requireNativeComponent } from 'react-native';
+    "name": "react-native-integration-view-test-package/index.js",
+    "theContent": "import { requireNativeComponent } from 'react-native';
 
 const IntegrationViewTestPackage = requireNativeComponent('IntegrationViewTestPackage', null);
 
 export default IntegrationViewTestPackage;
 ",
-    "name": "react-native-integration-view-test-package/index.js",
   },
   Object {
-    "contents": "#import <React/RCTViewManager.h>
+    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.h",
+    "theContent": "#import <React/RCTViewManager.h>
 
 @interface IntegrationViewTestPackage : RCTViewManager
 
 @end
 ",
-    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.h",
   },
   Object {
-    "contents": "#import \\"IntegrationViewTestPackage.h\\"
+    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.m",
+    "theContent": "#import \\"IntegrationViewTestPackage.h\\"
 
 @implementation IntegrationViewTestPackage
 
@@ -360,10 +361,10 @@ RCT_EXPORT_MODULE()
 
 @end
 ",
-    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.m",
   },
   Object {
-    "contents": "// !$*UTF8*$!
+    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.xcodeproj/project.pbxproj",
+    "theContent": "// !$*UTF8*$!
 {
 	archiveVersion = 1;
 	classes = {
@@ -635,10 +636,10 @@ RCT_EXPORT_MODULE()
 	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
 }
 ",
-    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.xcodeproj/project.pbxproj",
   },
   Object {
-    "contents": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.xcworkspace/contents.xcworkspacedata",
+    "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <Workspace
    version = \\"1.0\\">
    <FileRef
@@ -646,10 +647,10 @@ RCT_EXPORT_MODULE()
    </FileRef>
 </Workspace>
 ",
-    "name": "react-native-integration-view-test-package/ios/IntegrationViewTestPackage.xcworkspace/contents.xcworkspacedata",
   },
   Object {
-    "contents": "{
+    "name": "react-native-integration-view-test-package/package.json",
+    "theContent": "{
   \\"name\\": \\"react-native-integration-view-test-package\\",
   \\"title\\": \\"React Native Integration View Test Package\\",
   \\"version\\": \\"1.0.0\\",
@@ -683,10 +684,10 @@ RCT_EXPORT_MODULE()
   }
 }
 ",
-    "name": "react-native-integration-view-test-package/package.json",
   },
   Object {
-    "contents": "require \\"json\\"
+    "name": "react-native-integration-view-test-package/react-native-integration-view-test-package.podspec",
+    "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
@@ -713,7 +714,6 @@ Pod::Spec.new do |s|
 end
 
 ",
-    "name": "react-native-integration-view-test-package/react-native-integration-view-test-package.podspec",
   },
 ]
 `;

--- a/tests/integration/cli/create/view/cli-create-with-view.test.js
+++ b/tests/integration/cli/create/view/cli-create-with-view.test.js
@@ -1,0 +1,35 @@
+const execa = require('execa');
+const path = require('path');
+
+const readdirs = require('recursive-readdir');
+
+const fs = require('fs-extra');
+
+test('CLI creates correct view module package artifacts on file system using `--view` option (and no other options)', async () => {
+  const mysnap = [];
+
+  // remove test artifacts just in case:
+  fs.removeSync(`react-native-integration-view-test-package`);
+
+  await execa.command(
+    `node ${path.resolve('bin/cli.js')} --view integration-view-test-package`);
+
+  const filesUnsorted =
+    await readdirs('react-native-integration-view-test-package');
+
+  // with sorting, since underlying readdirs does not guarantee the order
+  // (using [].concat() function call to avoid overwriting a local object)
+  const files = [].concat(filesUnsorted).sort();
+
+  files.forEach(name =>
+    mysnap.push({
+      name: name.replace(/\\/g, '/'),
+      contents: fs.readFileSync(name).toString()
+    })
+  );
+
+  expect(mysnap).toMatchSnapshot();
+
+  // cleanup generated test artifacts:
+  fs.removeSync(`react-native-integration-view-test-package`);
+});

--- a/tests/integration/cli/create/view/cli-create-with-view.test.js
+++ b/tests/integration/cli/create/view/cli-create-with-view.test.js
@@ -10,7 +10,7 @@ test('CLI creates correct view module package artifacts on file system using `--
 
   const name = `integration-view-test-package`;
 
-  const modulePackageName = `react-native-${name}`
+  const modulePackageName = `react-native-${name}`;
 
   // remove test artifacts just in case:
   await fs.remove(modulePackageName);

--- a/tests/integration/cli/create/view/cli-create-with-view.test.js
+++ b/tests/integration/cli/create/view/cli-create-with-view.test.js
@@ -23,12 +23,15 @@ test('CLI creates correct view module package artifacts on file system using `--
   // (using [].concat() function call to avoid overwriting a local object)
   const files = [].concat(filesUnsorted).sort();
 
-  files.forEach(name =>
+  // THANKS for guidance:
+  // https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop/37576787#37576787
+  // FUTURE TBD use a utility function to do this more functionally
+  for (const path of files) {
     mysnap.push({
-      name: name.replace(/\\/g, '/'),
-      contents: fs.readFileSync(name).toString()
-    })
-  );
+      name: path.replace(/\\/g, '/'),
+      contents: await fs.readFile(path, 'utf8')
+    });
+  }
 
   expect(mysnap).toMatchSnapshot();
 

--- a/tests/integration/cli/create/view/cli-create-with-view.test.js
+++ b/tests/integration/cli/create/view/cli-create-with-view.test.js
@@ -29,7 +29,7 @@ test('CLI creates correct view module package artifacts on file system using `--
   for (const path of files) {
     mysnap.push({
       name: path.replace(/\\/g, '/'),
-      contents: await fs.readFile(path, 'utf8')
+      theContent: await fs.readFile(path, 'utf8')
     });
   }
 

--- a/tests/integration/cli/create/view/cli-create-with-view.test.js
+++ b/tests/integration/cli/create/view/cli-create-with-view.test.js
@@ -8,14 +8,16 @@ const fs = require('fs-extra');
 test('CLI creates correct view module package artifacts on file system using `--view` option (and no other options)', async () => {
   const mysnap = [];
 
+  const name = `integration-view-test-package`;
+
+  const modulePackageName = `react-native-${name}`
+
   // remove test artifacts just in case:
-  fs.removeSync(`react-native-integration-view-test-package`);
+  await fs.remove(modulePackageName);
 
-  await execa.command(
-    `node ${path.resolve('bin/cli.js')} --view integration-view-test-package`);
+  await execa.command(`node ${path.resolve('bin/cli.js')} --view ${name}`);
 
-  const filesUnsorted =
-    await readdirs('react-native-integration-view-test-package');
+  const filesUnsorted = await readdirs(modulePackageName);
 
   // with sorting, since underlying readdirs does not guarantee the order
   // (using [].concat() function call to avoid overwriting a local object)
@@ -31,5 +33,5 @@ test('CLI creates correct view module package artifacts on file system using `--
   expect(mysnap).toMatchSnapshot();
 
   // cleanup generated test artifacts:
-  fs.removeSync(`react-native-integration-view-test-package`);
+  await fs.remove(modulePackageName);
 });

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -3,12 +3,13 @@
 exports[`CLI creates correct package artifacts on file system, with no options 1`] = `
 Array [
   Object {
-    "contents": "*.pbxproj -text
-",
     "name": "react-native-integration-test-package/.gitattributes",
+    "theContent": "*.pbxproj -text
+",
   },
   Object {
-    "contents": "# OSX
+    "name": "react-native-integration-test-package/.gitignore",
+    "theContent": "# OSX
 #
 .DS_Store
 
@@ -51,14 +52,14 @@ buck-out/
 \\\\.buckd/
 *.keystore
 ",
-    "name": "react-native-integration-test-package/.gitignore",
   },
   Object {
-    "contents": "",
     "name": "react-native-integration-test-package/.npmignore",
+    "theContent": "",
   },
   Object {
-    "contents": "# react-native-integration-test-package
+    "name": "react-native-integration-test-package/README.md",
+    "theContent": "# react-native-integration-test-package
 
 ## Getting started
 
@@ -102,10 +103,10 @@ import IntegrationTestPackage from 'react-native-integration-test-package';
 IntegrationTestPackage;
 \`\`\`
 ",
-    "name": "react-native-integration-test-package/README.md",
   },
   Object {
-    "contents": "README
+    "name": "react-native-integration-test-package/android/README.md",
+    "theContent": "README
 ======
 
 If you want to publish the lib as a maven dependency, follow these steps before publishing a new version to npm:
@@ -120,10 +121,10 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 4. Run \`sudo ./gradlew installArchives\`
 5. Verify that latest set of generated files is in the maven folder with the correct version number
 ",
-    "name": "react-native-integration-test-package/android/README.md",
   },
   Object {
-    "contents": "buildscript {
+    "name": "react-native-integration-test-package/android/build.gradle",
+    "theContent": "buildscript {
     ext.safeExtGet = {prop, fallback ->
         rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
     }
@@ -251,18 +252,18 @@ afterEvaluate { project ->
     }
 }
 ",
-    "name": "react-native-integration-test-package/android/build.gradle",
   },
   Object {
-    "contents": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+    "name": "react-native-integration-test-package/android/src/main/AndroidManifest.xml",
+    "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
           package=\\"com.reactlibrary\\">
 
 </manifest>
 ",
-    "name": "react-native-integration-test-package/android/src/main/AndroidManifest.xml",
   },
   Object {
-    "contents": "package com.reactlibrary;
+    "name": "react-native-integration-test-package/android/src/main/java/com/reactlibrary/IntegrationTestPackageModule.java",
+    "theContent": "package com.reactlibrary;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -290,10 +291,10 @@ public class IntegrationTestPackageModule extends ReactContextBaseJavaModule {
     }
 }
 ",
-    "name": "react-native-integration-test-package/android/src/main/java/com/reactlibrary/IntegrationTestPackageModule.java",
   },
   Object {
-    "contents": "package com.reactlibrary;
+    "name": "react-native-integration-test-package/android/src/main/java/com/reactlibrary/IntegrationTestPackagePackage.java",
+    "theContent": "package com.reactlibrary;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -317,28 +318,28 @@ public class IntegrationTestPackagePackage implements ReactPackage {
     }
 }
 ",
-    "name": "react-native-integration-test-package/android/src/main/java/com/reactlibrary/IntegrationTestPackagePackage.java",
   },
   Object {
-    "contents": "import { NativeModules } from 'react-native';
+    "name": "react-native-integration-test-package/index.js",
+    "theContent": "import { NativeModules } from 'react-native';
 
 const { IntegrationTestPackage } = NativeModules;
 
 export default IntegrationTestPackage;
 ",
-    "name": "react-native-integration-test-package/index.js",
   },
   Object {
-    "contents": "#import <React/RCTBridgeModule.h>
+    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.h",
+    "theContent": "#import <React/RCTBridgeModule.h>
 
 @interface IntegrationTestPackage : NSObject <RCTBridgeModule>
 
 @end
 ",
-    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.h",
   },
   Object {
-    "contents": "#import \\"IntegrationTestPackage.h\\"
+    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.m",
+    "theContent": "#import \\"IntegrationTestPackage.h\\"
 
 
 @implementation IntegrationTestPackage
@@ -353,10 +354,10 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 @end
 ",
-    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.m",
   },
   Object {
-    "contents": "// !$*UTF8*$!
+    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.xcodeproj/project.pbxproj",
+    "theContent": "// !$*UTF8*$!
 {
 	archiveVersion = 1;
 	classes = {
@@ -628,10 +629,10 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
 }
 ",
-    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.xcodeproj/project.pbxproj",
   },
   Object {
-    "contents": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.xcworkspace/contents.xcworkspacedata",
+    "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <Workspace
    version = \\"1.0\\">
    <FileRef
@@ -639,10 +640,10 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
    </FileRef>
 </Workspace>
 ",
-    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.xcworkspace/contents.xcworkspacedata",
   },
   Object {
-    "contents": "{
+    "name": "react-native-integration-test-package/package.json",
+    "theContent": "{
   \\"name\\": \\"react-native-integration-test-package\\",
   \\"title\\": \\"React Native Integration Test Package\\",
   \\"version\\": \\"1.0.0\\",
@@ -676,10 +677,10 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   }
 }
 ",
-    "name": "react-native-integration-test-package/package.json",
   },
   Object {
-    "contents": "require \\"json\\"
+    "name": "react-native-integration-test-package/react-native-integration-test-package.podspec",
+    "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
@@ -706,7 +707,6 @@ Pod::Spec.new do |s|
 end
 
 ",
-    "name": "react-native-integration-test-package/react-native-integration-test-package.podspec",
   },
 ]
 `;

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -1,0 +1,712 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI creates correct package artifacts on file system, with no options 1`] = `
+Array [
+  Object {
+    "contents": "*.pbxproj -text
+",
+    "name": "react-native-integration-test-package/.gitattributes",
+  },
+  Object {
+    "contents": "# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# BUCK
+buck-out/
+\\\\.buckd/
+*.keystore
+",
+    "name": "react-native-integration-test-package/.gitignore",
+  },
+  Object {
+    "contents": "",
+    "name": "react-native-integration-test-package/.npmignore",
+  },
+  Object {
+    "contents": "# react-native-integration-test-package
+
+## Getting started
+
+\`$ npm install react-native-integration-test-package --save\`
+
+### Mostly automatic installation
+
+\`$ react-native link react-native-integration-test-package\`
+
+### Manual installation
+
+
+#### iOS
+
+1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
+2. Go to \`node_modules\` ➜ \`react-native-integration-test-package\` and add \`IntegrationTestPackage.xcodeproj\`
+3. In XCode, in the project navigator, select your project. Add \`libIntegrationTestPackage.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
+4. Run your project (\`Cmd+R\`)<
+
+#### Android
+
+1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
+  - Add \`import com.reactlibrary.IntegrationTestPackagePackage;\` to the imports at the top of the file
+  - Add \`new IntegrationTestPackagePackage()\` to the list returned by the \`getPackages()\` method
+2. Append the following lines to \`android/settings.gradle\`:
+  	\`\`\`
+  	include ':react-native-integration-test-package'
+  	project(':react-native-integration-test-package').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-integration-test-package/android')
+  	\`\`\`
+3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
+  	\`\`\`
+      compile project(':react-native-integration-test-package')
+  	\`\`\`
+
+
+## Usage
+\`\`\`javascript
+import IntegrationTestPackage from 'react-native-integration-test-package';
+
+// TODO: What to do with the module?
+IntegrationTestPackage;
+\`\`\`
+",
+    "name": "react-native-integration-test-package/README.md",
+  },
+  Object {
+    "contents": "README
+======
+
+If you want to publish the lib as a maven dependency, follow these steps before publishing a new version to npm:
+
+1. Be sure to have the Android [SDK](https://developer.android.com/studio/index.html) and [NDK](https://developer.android.com/ndk/guides/index.html) installed
+2. Be sure to have a \`local.properties\` file in this folder that points to the Android SDK and NDK
+\`\`\`
+ndk.dir=/Users/{username}/Library/Android/sdk/ndk-bundle
+sdk.dir=/Users/{username}/Library/Android/sdk
+\`\`\`
+3. Delete the \`maven\` folder
+4. Run \`sudo ./gradlew installArchives\`
+5. Verify that latest set of generated files is in the maven folder with the correct version number
+",
+    "name": "react-native-integration-test-package/android/README.md",
+  },
+  Object {
+    "contents": "buildscript {
+    ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        // Matches recent template from React Native (0.60)
+        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L16
+        classpath(\\"com.android.tools.build:gradle:\${safeExtGet('gradlePluginVersion', '3.4.1')}\\")
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'maven'
+
+// Matches values in recent template from React Native 0.59 / 0.60
+// https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
+// https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L5-L9
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = \\"28.0.3\\"
+def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_TARGET_SDK_VERSION = 28
+
+android {
+  compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+  buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
+
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+    targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
+    versionCode 1
+    versionName \\"1.0\\"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}
+
+repositories {
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        // Matches recent template from React Native 0.59 / 0.60
+        // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L30
+        // https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle#L28
+        url \\"$projectDir/../node_modules/react-native/android\\"
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation \\"com.facebook.react:react-native:\${safeExtGet('reactnativeVersion', '+')}\\"
+}
+
+def configureReactNativePom(def pom) {
+    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
+
+    pom.project {
+        name packageJson.title
+        artifactId packageJson.name
+        version = packageJson.version
+        group = \\"com.reactlibrary\\"
+        description packageJson.description
+        url packageJson.repository.baseUrl
+
+        licenses {
+            license {
+                name packageJson.license
+                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                distribution 'repo'
+            }
+        }
+
+        developers {
+            developer {
+                id packageJson.author.username
+                name packageJson.author.name
+            }
+        }
+    }
+}
+
+afterEvaluate { project ->
+
+    task androidJavadoc(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += files(android.bootClasspath)
+        classpath += files(project.getConfigurations().getByName('compile').asList())
+        include '**/*.java'
+    }
+
+    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+        classifier = 'javadoc'
+        from androidJavadoc.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.srcDirs
+        include '**/*.java'
+    }
+
+    android.libraryVariants.all { variant ->
+        def name = variant.name.capitalize()
+        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
+            from variant.javaCompile.destinationDir
+        }
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocJar
+    }
+
+    task installArchives(type: Upload) {
+        configuration = configurations.archives
+        repositories.mavenDeployer {
+            // Deploy to react-native-event-bridge/maven, ready to publish to npm
+            repository url: \\"file://\${projectDir}/../android/maven\\"
+
+            configureReactNativePom pom
+        }
+    }
+}
+",
+    "name": "react-native-integration-test-package/android/build.gradle",
+  },
+  Object {
+    "contents": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+          package=\\"com.reactlibrary\\">
+
+</manifest>
+",
+    "name": "react-native-integration-test-package/android/src/main/AndroidManifest.xml",
+  },
+  Object {
+    "contents": "package com.reactlibrary;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Callback;
+
+public class IntegrationTestPackageModule extends ReactContextBaseJavaModule {
+
+    private final ReactApplicationContext reactContext;
+
+    public IntegrationTestPackageModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        this.reactContext = reactContext;
+    }
+
+    @Override
+    public String getName() {
+        return \\"IntegrationTestPackage\\";
+    }
+
+    @ReactMethod
+    public void sampleMethod(String stringArgument, int numberArgument, Callback callback) {
+        // TODO: Implement some actually useful functionality
+        callback.invoke(\\"Received numberArgument: \\" + numberArgument + \\" stringArgument: \\" + stringArgument);
+    }
+}
+",
+    "name": "react-native-integration-test-package/android/src/main/java/com/reactlibrary/IntegrationTestPackageModule.java",
+  },
+  Object {
+    "contents": "package com.reactlibrary;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
+
+public class IntegrationTestPackagePackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Arrays.<NativeModule>asList(new IntegrationTestPackageModule(reactContext));
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}
+",
+    "name": "react-native-integration-test-package/android/src/main/java/com/reactlibrary/IntegrationTestPackagePackage.java",
+  },
+  Object {
+    "contents": "import { NativeModules } from 'react-native';
+
+const { IntegrationTestPackage } = NativeModules;
+
+export default IntegrationTestPackage;
+",
+    "name": "react-native-integration-test-package/index.js",
+  },
+  Object {
+    "contents": "#import <React/RCTBridgeModule.h>
+
+@interface IntegrationTestPackage : NSObject <RCTBridgeModule>
+
+@end
+",
+    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.h",
+  },
+  Object {
+    "contents": "#import \\"IntegrationTestPackage.h\\"
+
+
+@implementation IntegrationTestPackage
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
+{
+    // TODO: Implement some actually useful functionality
+	callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@\\", numberArgument, stringArgument]]);
+}
+
+@end
+",
+    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.m",
+  },
+  Object {
+    "contents": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B3E7B58A1CC2AC0600A0062D /* IntegrationTestPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* IntegrationTestPackage.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = \\"include/$(PRODUCT_NAME)\\";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libIntegrationTestPackage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libIntegrationTestPackage.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E7B5881CC2AC0600A0062D /* IntegrationTestPackage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntegrationTestPackage.h; sourceTree = \\"<group>\\"; };
+		B3E7B5891CC2AC0600A0062D /* IntegrationTestPackage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntegrationTestPackage.m; sourceTree = \\"<group>\\"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libIntegrationTestPackage.a */,
+			);
+			name = Products;
+			sourceTree = \\"<group>\\";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				B3E7B5881CC2AC0600A0062D /* IntegrationTestPackage.h */,
+				B3E7B5891CC2AC0600A0062D /* IntegrationTestPackage.m */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* IntegrationTestPackage */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"IntegrationTestPackage\\" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IntegrationTestPackage;
+			productName = RCTDataManager;
+			productReference = 134814201AA4EA6300B7C361 /* libIntegrationTestPackage.a */;
+			productType = \\"com.apple.product-type.library.static\\";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"IntegrationTestPackage\\" */;
+			compatibilityVersion = \\"Xcode 3.2\\";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = \\"\\";
+			projectRoot = \\"\\";
+			targets = (
+				58B511DA1A9E6C8500147676 /* IntegrationTestPackage */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3E7B58A1CC2AC0600A0062D /* IntegrationTestPackage.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"DEBUG=1\\",
+					\\"$(inherited)\\",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+				\\"$(inherited)\\",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					\\"$(SRCROOT)/../../../React/**\\",
+					\\"$(SRCROOT)/../../react-native/React/**\\",
+				);
+				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
+				OTHER_LDFLAGS = \\"-ObjC\\";
+				PRODUCT_NAME = IntegrationTestPackage;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					\\"$(inherited)\\",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					\\"$(SRCROOT)/../../../React/**\\",
+					\\"$(SRCROOT)/../../react-native/React/**\\",
+				);
+				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
+				OTHER_LDFLAGS = \\"-ObjC\\";
+				PRODUCT_NAME = IntegrationTestPackage;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"IntegrationTestPackage\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"IntegrationTestPackage\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}
+",
+    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.xcodeproj/project.pbxproj",
+  },
+  Object {
+    "contents": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<Workspace
+   version = \\"1.0\\">
+   <FileRef
+      location = \\"group:IntegrationTestPackage.xcodeproj\\">
+   </FileRef>
+</Workspace>
+",
+    "name": "react-native-integration-test-package/ios/IntegrationTestPackage.xcworkspace/contents.xcworkspacedata",
+  },
+  Object {
+    "contents": "{
+  \\"name\\": \\"react-native-integration-test-package\\",
+  \\"title\\": \\"React Native Integration Test Package\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"TODO\\",
+  \\"main\\": \\"index.js\\",
+  \\"scripts\\": {
+    \\"test\\": \\"echo \\\\\\"Error: no test specified\\\\\\" && exit 1\\"
+  },
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"git+https://github.com/github_account/react-native-integration-test-package.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-integration-test-package\\"
+  },
+  \\"keywords\\": [
+    \\"react-native\\"
+  ],
+  \\"author\\": {
+    \\"name\\": \\"Your Name\\",
+    \\"email\\": \\"yourname@email.com\\"
+  },
+  \\"license\\": \\"MIT\\",
+  \\"licenseFilename\\": \\"LICENSE\\",
+  \\"readmeFilename\\": \\"README.md\\",
+  \\"peerDependencies\\": {
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+  },
+  \\"devDependencies\\": {
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
+  }
+}
+",
+    "name": "react-native-integration-test-package/package.json",
+  },
+  Object {
+    "contents": "require \\"json\\"
+
+package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
+
+Pod::Spec.new do |s|
+  s.name         = \\"react-native-integration-test-package\\"
+  s.version      = package[\\"version\\"]
+  s.summary      = package[\\"description\\"]
+  s.description  = <<-DESC
+                  react-native-integration-test-package
+                   DESC
+  s.homepage     = \\"https://github.com/github_account/react-native-integration-test-package\\"
+  s.license      = \\"MIT\\"
+  # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
+  s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
+  s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-integration-test-package.git\\", :tag => \\"#{s.version}\\" }
+
+  s.source_files = \\"ios/**/*.{h,m,swift}\\"
+  s.requires_arc = true
+
+  s.dependency \\"React\\"
+	
+  # s.dependency \\"...\\"
+end
+
+",
+    "name": "react-native-integration-test-package/react-native-integration-test-package.podspec",
+  },
+]
+`;

--- a/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
+++ b/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
@@ -1,0 +1,35 @@
+const execa = require('execa');
+const path = require('path');
+
+const readdirs = require('recursive-readdir');
+
+const fs = require('fs-extra');
+
+test('CLI creates correct package artifacts on file system, with no options', async () => {
+  const mysnap = [];
+
+  // remove test artifacts just in case:
+  fs.removeSync(`react-native-integration-test-package`);
+
+  await execa.command(
+    `node ${path.resolve('bin/cli.js')} integration-test-package`);
+
+  const filesUnsorted =
+    await readdirs('react-native-integration-test-package');
+
+  // with sorting, since underlying readdirs does not guarantee the order
+  // (using [].concat() function call to avoid overwriting a local object)
+  const files = [].concat(filesUnsorted).sort();
+
+  files.forEach(name =>
+    mysnap.push({
+      name: name.replace(/\\/g, '/'),
+      contents: fs.readFileSync(name).toString()
+    })
+  );
+
+  expect(mysnap).toMatchSnapshot();
+
+  // cleanup generated test artifacts:
+  fs.removeSync(`react-native-integration-test-package`);
+});

--- a/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
+++ b/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
@@ -10,7 +10,7 @@ test('CLI creates correct package artifacts on file system, with no options', as
 
   const name = `integration-test-package`;
 
-  const modulePackageName = `react-native-${name}`
+  const modulePackageName = `react-native-${name}`;
 
   // remove test artifacts just in case:
   await fs.remove(modulePackageName);

--- a/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
+++ b/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
@@ -23,12 +23,15 @@ test('CLI creates correct package artifacts on file system, with no options', as
   // (using [].concat() function call to avoid overwriting a local object)
   const files = [].concat(filesUnsorted).sort();
 
-  files.forEach(name =>
+  // THANKS for guidance:
+  // https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop/37576787#37576787
+  // FUTURE TBD use a utility function to do this more functionally
+  for (const path of files) {
     mysnap.push({
-      name: name.replace(/\\/g, '/'),
-      contents: fs.readFileSync(name).toString()
-    })
-  );
+      name: path.replace(/\\/g, '/'),
+      contents: await fs.readFile(path, 'utf8')
+    });
+  }
 
   expect(mysnap).toMatchSnapshot();
 

--- a/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
+++ b/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
@@ -8,14 +8,16 @@ const fs = require('fs-extra');
 test('CLI creates correct package artifacts on file system, with no options', async () => {
   const mysnap = [];
 
+  const name = `integration-test-package`;
+
+  const modulePackageName = `react-native-${name}`
+
   // remove test artifacts just in case:
-  fs.removeSync(`react-native-integration-test-package`);
+  await fs.remove(modulePackageName);
 
-  await execa.command(
-    `node ${path.resolve('bin/cli.js')} integration-test-package`);
+  await execa.command(`node ${path.resolve('bin/cli.js')} ${name}`);
 
-  const filesUnsorted =
-    await readdirs('react-native-integration-test-package');
+  const filesUnsorted = await readdirs(modulePackageName);
 
   // with sorting, since underlying readdirs does not guarantee the order
   // (using [].concat() function call to avoid overwriting a local object)
@@ -31,5 +33,5 @@ test('CLI creates correct package artifacts on file system, with no options', as
   expect(mysnap).toMatchSnapshot();
 
   // cleanup generated test artifacts:
-  fs.removeSync(`react-native-integration-test-package`);
+  await fs.remove(modulePackageName);
 });

--- a/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
+++ b/tests/integration/cli/create/with-defaults/cli-create-with-defaults.test.js
@@ -29,7 +29,7 @@ test('CLI creates correct package artifacts on file system, with no options', as
   for (const path of files) {
     mysnap.push({
       name: path.replace(/\\/g, '/'),
-      contents: await fs.readFile(path, 'utf8')
+      theContent: await fs.readFile(path, 'utf8')
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3114,7 +3114,7 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -3849,6 +3849,13 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+recursive-readdir@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
+  integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
+  dependencies:
+    minimatch "3.0.4"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
_with and without the `--view` option_

using `recursive-readdir` _(with additional sorting of the file path list)_ & `fs.readFileSync()` to _read and check_ the contents of the generated library module artifacts

with the generated test artifacts ignored as specified by added `.gitignore` entries (this is a departure from a common approach of running this kind of test in a temporary directory, using a utility package such as `tmp` or perhaps `temp-dir`)

/cc @dlowder-salesforce @dsyne