### PR TITLE
[wip/???] drop react native 0.59 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
 
 - **React Native versions supported:**
   - recommended: `0.60`, `0.61-rc` (see known quirks and issues below)
-  - outdated: `0.59`
+  - ~~outdated: `0.59`~~
 - Known quirks & issues on React Native 0.60(+):
   - [issue #99](https://github.com/brodybits/create-react-native-module/issues/99) - additional `pod install` step needed for RN 0.60 on iOS
   - [issue #29](https://github.com/brodybits/create-react-native-module/issues/29) - View does not work with RN 0.60 on Android (quick patch needed)
@@ -94,7 +94,7 @@ Options:
   --prefix <prefix>                         The prefix for the library module (Default: ``)
   --module-name <moduleName>                The module library package name to be used in package.json. Default: react-native-(name in param-case)
   --module-prefix <modulePrefix>            The module prefix for the library module, ignored if --module-name is specified (Default: `react-native`)
-  --minimum-react-native-version <version>  Minimum supported React Native version, must be semver (default: `0.59.0-rc.0`)
+  --minimum-react-native-version <version>  Minimum supported React Native version, must be semver (default: `0.60.0`)
   --package-identifier <packageIdentifier>  (Android only!) The package name for the Android module (Default: `com.reactlibrary`)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
   --github-account <githubAccount>          The github account where the library module is hosted (Default: `github_account`)
@@ -129,7 +129,7 @@ createLibraryModule({
   prefix: String, /* The prefix for the library (Default: ``) */
   moduleName: String, /* The module library package name to be used in package.json. Default: react-native-(name in param-case) */
   modulePrefix: String, /* The module prefix for the library, ignored if moduleName is specified (Default: react-native) */
-  minimumReactNativeVersion: String, /* Minimum supported React Native version, must be semver (Default: `0.59.0-rc.0`) */
+  minimumReactNativeVersion: String, /* Minimum supported React Native version, must be semver (Default: `0.60.0`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
   packageIdentifier: String, /* (Android only!) The package name for the Android module (Default: com.reactlibrary) */
   githubAccount: String, /* The github account where the library is hosted (Default: `github_account`) */

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
   - React Native 0.60(+) currently not supported by Expo or react-native-windows
 - Out-of-tree platform support
   - tvOS platform support - unstable (not tested) (see [issue #95](https://github.com/brodybits/create-react-native-module/issues/95))
-  - Windows - unstable (not tested, see [issue #23](https://github.com/brodybits/create-react-native-module/issues/23)); now deprecated and may be removed in the near future (see [issue #43](https://github.com/brodybits/create-react-native-module/issues/43))
+  - Windows - unstable _and known to be broken by the recent updates_ (not tested, see [issue #23](https://github.com/brodybits/create-react-native-module/issues/23)); now deprecated and may be removed in the near future (see [issue #43](https://github.com/brodybits/create-react-native-module/issues/43))
   - for future consideration: macOS (see [issue #94](https://github.com/brodybits/create-react-native-module/issues/94))
 - Node.js pre-10 support is deprecated and will be removed in the near future (see [issue #38](https://github.com/brodybits/create-react-native-module/issues/38))
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Options:
   --use-cocoapods                           Generate a library with a sample podspec and third party pod usage example
   --generate-example                        Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name <exampleName>              Name for the example project (default: `example`)
-  --example-react-native-version <version>  React Native version for the generated example project (default: `react-native@0.59`)
+  --example-react-native-version <version>  React Native version for the generated example project (default: `react-native@latest`)
   -h, --help                                output usage information
 ```
 
@@ -138,7 +138,7 @@ createLibraryModule({
   view: Boolean, /* Generate the module as a very simple native view component (Default: false) */
   generateExample: Boolean, /* Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally (Default: false) */
   exampleName: String, /* Name for the example project (Default: `example`) */
-  exampleReactNativeVersion: String, /* React Native version for the generated example project (Default: `react-native@0.59`) */
+  exampleReactNativeVersion: String, /* React Native version for the generated example project (Default: `react-native@latest`) */
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Options:
   --prefix <prefix>                         The prefix for the library module (Default: ``)
   --module-name <moduleName>                The module library package name to be used in package.json. Default: react-native-(name in param-case)
   --module-prefix <modulePrefix>            The module prefix for the library module, ignored if --module-name is specified (Default: `react-native`)
+  --minimum-react-native-version <version>  Minimum supported React Native version, must be semver (default: `0.59.0-rc.0`)
   --package-identifier <packageIdentifier>  (Android only!) The package name for the Android module (Default: `com.reactlibrary`)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
   --github-account <githubAccount>          The github account where the library module is hosted (Default: `github_account`)
@@ -128,6 +129,7 @@ createLibraryModule({
   prefix: String, /* The prefix for the library (Default: ``) */
   moduleName: String, /* The module library package name to be used in package.json. Default: react-native-(name in param-case) */
   modulePrefix: String, /* The module prefix for the library, ignored if moduleName is specified (Default: react-native) */
+  minimumReactNativeVersion: String, /* Minimum supported React Native version, must be semver (Default: `0.59.0-rc.0`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
   packageIdentifier: String, /* (Android only!) The package name for the Android module (Default: com.reactlibrary) */
   githubAccount: String, /* The github account where the library is hosted (Default: `github_account`) */

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -107,6 +107,6 @@ ${postCreateInstructions(createOptions)}`);
   }, {
     command: '--example-react-native-version [exampleReactNativeVersion]',
     description: 'React Native version for the generated example project',
-    default: 'react-native@0.59',
+    default: 'react-native@latest',
   }]
 };

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -70,7 +70,7 @@ ${postCreateInstructions(createOptions)}`);
   }, {
     command: '--minimum-react-native-version [minimumReactNativeVersion]',
     description: 'Minimum supported React Native version, must be semver',
-    default: '0.59.0-rc.0',
+    default: '0.60.0',
   }, {
     command: '--package-identifier [packageIdentifier]',
     description: '(Android only!) The package name for the Android module',

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -68,6 +68,10 @@ ${postCreateInstructions(createOptions)}`);
     description: 'The module prefix for the library module, ignored if --module-name is specified',
     default: 'react-native',
   }, {
+    command: '--minimum-react-native-version [minimumReactNativeVersion]',
+    description: 'Minimum supported React Native version, must be semver',
+    default: '0.59.0-rc.0',
+  }, {
     command: '--package-identifier [packageIdentifier]',
     description: '(Android only!) The package name for the Android module',
     default: 'com.reactlibrary',

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -52,6 +52,7 @@ const generateWithNormalizedOptions = ({
   moduleName,
   className,
   modulePrefix,
+  minimumReactNativeVersion = '0.59.0-rc.0',
   packageIdentifier = DEFAULT_PACKAGE_IDENTIFIER,
   namespace,
   platforms = DEFAULT_PLATFORMS,
@@ -84,6 +85,7 @@ const generateWithNormalizedOptions = ({
   name: ${name}
   prefix: ${prefix}
   modulePrefix: ${modulePrefix}
+  minimumReactNativeVersion: ${minimumReactNativeVersion}
   packageIdentifier: ${packageIdentifier}
   platforms: ${platforms}
   githubAccount: ${githubAccount}
@@ -140,6 +142,7 @@ const generateWithNormalizedOptions = ({
         const templateArgs = {
           name: className,
           moduleName,
+          minimumReactNativeVersion,
           packageIdentifier,
           namespace,
           platforms,

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -52,7 +52,7 @@ const generateWithNormalizedOptions = ({
   moduleName,
   className,
   modulePrefix,
-  minimumReactNativeVersion = '0.59.0-rc.0',
+  minimumReactNativeVersion = '0.60.0',
   packageIdentifier = DEFAULT_PACKAGE_IDENTIFIER,
   namespace,
   platforms = DEFAULT_PLATFORMS,

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -31,7 +31,7 @@ const DEFAULT_LICENSE = 'MIT';
 const DEFAULT_USE_COCOAPODS = false;
 const DEFAULT_GENERATE_EXAMPLE = false;
 const DEFAULT_EXAMPLE_NAME = 'example';
-const DEFAULT_EXAMPLE_REACT_NATIVE_VERSION = 'react-native@0.59';
+const DEFAULT_EXAMPLE_REACT_NATIVE_VERSION = 'react-native@latest';
 
 const renderTemplateIfValid = (fs, root, template, templateArgs) => {
   // avoid throwing an exception in case there is no valid template.name member

--- a/templates/general.js
+++ b/templates/general.js
@@ -86,7 +86,7 @@ ${name};
     const devDependencies =
       `{
     "react": "^16.8.3",
-    "react-native": "^0.59.10"` +
+    "react-native": "^0.60.5"` +
         (withWindows
           ? `,
     "react-native-windows": "^0.59.0-rc.1"`

--- a/templates/general.js
+++ b/templates/general.js
@@ -70,13 +70,13 @@ ${name};
   },
 }, {
   name: () => 'package.json',
-  content: ({ moduleName, platforms, githubAccount, authorName, authorEmail, license }) => {
+  content: ({ moduleName, platforms, minimumReactNativeVersion, githubAccount, authorName, authorEmail, license }) => {
     const withWindows = platforms.indexOf('windows') >= 0;
 
     const peerDependencies =
       `{
     "react": "^16.8.1",
-    "react-native": ">=0.59.0-rc.0 <1.0.x"` +
+    "react-native": ">=${minimumReactNativeVersion} <1.0.x"` +
       (withWindows
         ? `,
     "react-native-windows": ">=0.59.0-rc.0 <1.0.x"`

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -680,7 +680,7 @@ RCT_EXPORT_MODULE()
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 ",

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -676,7 +676,7 @@ RCT_EXPORT_MODULE()
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -669,7 +669,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -673,7 +673,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 ",

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -20,6 +20,6 @@ Options:
   --use-cocoapods                                             Generate a library with a sample podspec and third party pod usage example
   --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name [exampleName]                                Name for the example project (default: \\"example\\")
-  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")
+  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@latest\\")
   -h, --help                                                  output usage information"
 `;

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -10,6 +10,7 @@ Options:
   --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
   --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
   --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
+  --minimum-react-native-version [minimumReactNativeVersion]  Minimum supported React Native version, must be semver (default: \\"0.59.0-rc.0\\")
   --package-identifier [packageIdentifier]                    (Android only!) The package name for the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -10,7 +10,7 @@ Options:
   --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
   --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
   --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
-  --minimum-react-native-version [minimumReactNativeVersion]  Minimum supported React Native version, must be semver (default: \\"0.59.0-rc.0\\")
+  --minimum-react-native-version [minimumReactNativeVersion]  Minimum supported React Native version, must be semver (default: \\"0.60.0\\")
   --package-identifier [packageIdentifier]                    (Android only!) The package name for the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -20,6 +20,6 @@ Options:
   --use-cocoapods                                             Generate a library with a sample podspec and third party pod usage example
   --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name [exampleName]                                Name for the example project (default: \\"example\\")
-  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")
+  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@latest\\")
   -h, --help                                                  output usage information"
 `;

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -10,6 +10,7 @@ Options:
   --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
   --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
   --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
+  --minimum-react-native-version [minimumReactNativeVersion]  Minimum supported React Native version, must be semver (default: \\"0.59.0-rc.0\\")
   --package-identifier [packageIdentifier]                    (Android only!) The package name for the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -10,7 +10,7 @@ Options:
   --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
   --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
   --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
-  --minimum-react-native-version [minimumReactNativeVersion]  Minimum supported React Native version, must be semver (default: \\"0.59.0-rc.0\\")
+  --minimum-react-native-version [minimumReactNativeVersion]  Minimum supported React Native version, must be semver (default: \\"0.60.0\\")
   --package-identifier [packageIdentifier]                    (Android only!) The package name for the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -21,6 +21,11 @@ Object {
       "description": "The module prefix for the library module, ignored if --module-name is specified",
     },
     Object {
+      "command": "--minimum-react-native-version [minimumReactNativeVersion]",
+      "default": "0.59.0-rc.0",
+      "description": "Minimum supported React Native version, must be semver",
+    },
+    Object {
       "command": "--package-identifier [packageIdentifier]",
       "default": "com.reactlibrary",
       "description": "(Android only!) The package name for the Android module",

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -22,7 +22,7 @@ Object {
     },
     Object {
       "command": "--minimum-react-native-version [minimumReactNativeVersion]",
-      "default": "0.59.0-rc.0",
+      "default": "0.60.0",
       "description": "Minimum supported React Native version, must be semver",
     },
     Object {

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -69,7 +69,7 @@ Object {
     },
     Object {
       "command": "--example-react-native-version [exampleReactNativeVersion]",
-      "default": "react-native@0.59",
+      "default": "react-native@latest",
       "description": "React Native version for the generated example project",
     },
   ],

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -118,7 +118,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -114,7 +114,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -122,7 +122,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -786,7 +786,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* execa.commandSync command: react-native init example --version react-native@0.59 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+  "* execa.commandSync command: react-native init example --version react-native@latest options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -118,7 +118,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -122,7 +122,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -118,7 +118,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -97,7 +97,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -101,7 +101,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
@@ -89,7 +89,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
@@ -93,7 +93,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -118,7 +118,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -114,7 +114,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
@@ -72,7 +72,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
@@ -76,7 +76,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
@@ -72,7 +72,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
@@ -76,7 +76,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
@@ -72,7 +72,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
@@ -76,7 +76,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -122,7 +122,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -779,7 +779,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* execa.commandSync command: react-native init example --version react-native@0.59 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+  "* execa.commandSync command: react-native init example --version react-native@latest options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -118,7 +118,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -122,7 +122,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -779,7 +779,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* execa.commandSync command: react-native init example --version react-native@0.59 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+  "* execa.commandSync command: react-native init example --version react-native@latest options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -118,7 +118,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -122,7 +122,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -779,7 +779,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* execa.commandSync command: react-native init example --version react-native@0.59 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+  "* execa.commandSync command: react-native init example --version react-native@latest options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -118,7 +118,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -122,7 +122,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -118,7 +118,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -118,7 +118,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -114,7 +114,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -97,7 +97,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -101,7 +101,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -89,7 +89,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -93,7 +93,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -118,7 +118,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -114,7 +114,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -118,7 +118,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -114,7 +114,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -118,7 +118,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -114,7 +114,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -118,7 +118,7 @@ content:
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -114,7 +114,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -16,7 +16,7 @@ Array [
   name: alice-bobbi
   prefix: 
   modulePrefix: react-native
-  minimumReactNativeVersion: 0.59.0-rc.0
+  minimumReactNativeVersion: 0.60.0
   packageIdentifier: com.reactlibrary
   platforms: bogus
   githubAccount: github_account

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -16,6 +16,7 @@ Array [
   name: alice-bobbi
   prefix: 
   modulePrefix: react-native
+  minimumReactNativeVersion: 0.59.0-rc.0
   packageIdentifier: com.reactlibrary
   platforms: bogus
   githubAccount: github_account

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -16,6 +16,7 @@ Array [
   name: alice-bobbi
   prefix: 
   modulePrefix: react-native
+  minimumReactNativeVersion: 0.59.0-rc.0
   packageIdentifier: com.reactlibrary
   platforms: 
   githubAccount: github_account

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -16,7 +16,7 @@ Array [
   name: alice-bobbi
   prefix: 
   modulePrefix: react-native
-  minimumReactNativeVersion: 0.59.0-rc.0
+  minimumReactNativeVersion: 0.60.0
   packageIdentifier: com.reactlibrary
   platforms: 
   githubAccount: github_account

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -132,7 +132,7 @@ AliceBobbi;
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 ",

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -128,7 +128,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -276,7 +276,7 @@ TestPackage;
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 ",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -55,7 +55,7 @@ Array [
         "--minimum-react-native-version [minimumReactNativeVersion]",
         "Minimum supported React Native version, must be semver",
         [Function],
-        "0.59.0-rc.0",
+        "0.60.0",
       ],
     },
   },
@@ -282,7 +282,7 @@ TestPackage;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -52,6 +52,16 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--minimum-react-native-version [minimumReactNativeVersion]",
+        "Minimum supported React Native version, must be semver",
+        [Function],
+        "0.59.0-rc.0",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--package-identifier [packageIdentifier]",
         "(Android only!) The package name for the Android module",
         [Function],

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -155,7 +155,7 @@ Array [
         "--example-react-native-version [exampleReactNativeVersion]",
         "React Native version for the generated example project",
         [Function],
-        "react-native@0.59",
+        "react-native@latest",
       ],
     },
   },

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -53,7 +53,7 @@ Array [
         "--minimum-react-native-version [minimumReactNativeVersion]",
         "Minimum supported React Native version, must be semver",
         [Function],
-        "0.59.0-rc.0",
+        "0.60.0",
       ],
     },
   },

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -50,6 +50,16 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--minimum-react-native-version [minimumReactNativeVersion]",
+        "Minimum supported React Native version, must be semver",
+        [Function],
+        "0.59.0-rc.0",
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--package-identifier [packageIdentifier]",
         "(Android only!) The package name for the Android module",
         [Function],

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -153,7 +153,7 @@ Array [
         "--example-react-native-version [exampleReactNativeVersion]",
         "React Native version for the generated example project",
         [Function],
-        "react-native@0.59",
+        "react-native@latest",
       ],
     },
   },

--- a/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
@@ -116,7 +116,7 @@ AliceBobbi;
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\",
+    \\"react-native\\": \\"^0.60.5\\",
     \\"react-native-windows\\": \\"^0.59.0-rc.1\\"
   }
 }

--- a/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
@@ -111,7 +111,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\",
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\",
     \\"react-native-windows\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -826,11 +826,11 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   Object {
     "info": Array [
-      "CREATE example app with the following command: react-native init example --version react-native@0.59",
+      "CREATE example app with the following command: react-native init example --version react-native@latest",
     ],
   },
   Object {
-    "commandSync": "react-native init example --version react-native@0.59",
+    "commandSync": "react-native init example --version react-native@latest",
     "options": Object {
       "cwd": "./react-native-alice-bobbi",
       "stdio": "inherit",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -196,7 +196,7 @@ AliceBobbi;
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -16,7 +16,7 @@ Array [
   name: alice-bobbi
   prefix: 
   modulePrefix: react-native
-  minimumReactNativeVersion: 0.59.0-rc.0
+  minimumReactNativeVersion: 0.60.0
   packageIdentifier: com.reactlibrary
   platforms: android,ios
   githubAccount: github_account
@@ -193,7 +193,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -16,6 +16,7 @@ Array [
   name: alice-bobbi
   prefix: 
   modulePrefix: react-native
+  minimumReactNativeVersion: 0.59.0-rc.0
   packageIdentifier: com.reactlibrary
   platforms: android,ios
   githubAccount: github_account

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -826,11 +826,11 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   Object {
     "info": Array [
-      "CREATE example app with the following command: react-native init example --version react-native@0.59",
+      "CREATE example app with the following command: react-native init example --version react-native@latest",
     ],
   },
   Object {
-    "commandSync": "react-native init example --version react-native@0.59",
+    "commandSync": "react-native init example --version react-native@latest",
     "options": Object {
       "cwd": "./react-native-alice-bobbi",
       "stdio": "inherit",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -196,7 +196,7 @@ AliceBobbi;
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -16,7 +16,7 @@ Array [
   name: alice-bobbi
   prefix: 
   modulePrefix: react-native
-  minimumReactNativeVersion: 0.59.0-rc.0
+  minimumReactNativeVersion: 0.60.0
   packageIdentifier: com.reactlibrary
   platforms: android,ios
   githubAccount: github_account
@@ -193,7 +193,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -16,6 +16,7 @@ Array [
   name: alice-bobbi
   prefix: 
   modulePrefix: react-native
+  minimumReactNativeVersion: 0.59.0-rc.0
   packageIdentifier: com.reactlibrary
   platforms: android,ios
   githubAccount: github_account

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -16,6 +16,7 @@ Array [
   name: alice-bobbi
   prefix: null
   modulePrefix: react-native
+  minimumReactNativeVersion: 0.59.0-rc.0
   packageIdentifier: com.reactlibrary
   platforms: android,ios
   githubAccount: github_account

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -826,11 +826,11 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   Object {
     "info": Array [
-      "CREATE example app with the following command: react-native init example --version react-native@0.59",
+      "CREATE example app with the following command: react-native init example --version react-native@latest",
     ],
   },
   Object {
-    "commandSync": "react-native init example --version react-native@0.59",
+    "commandSync": "react-native init example --version react-native@latest",
     "options": Object {
       "cwd": "./react-native-alice-bobbi",
       "stdio": "inherit",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -196,7 +196,7 @@ AliceBobbi;
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -16,7 +16,7 @@ Array [
   name: alice-bobbi
   prefix: null
   modulePrefix: react-native
-  minimumReactNativeVersion: 0.59.0-rc.0
+  minimumReactNativeVersion: 0.60.0
   packageIdentifier: com.reactlibrary
   platforms: android,ios
   githubAccount: github_account
@@ -193,7 +193,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -10,6 +10,7 @@ Array [
   name: alice-bobbi
   prefix: ABC
   modulePrefix: react-native
+  minimumReactNativeVersion: 0.59.0-rc.0
   packageIdentifier: com.alicebits
   platforms: android,ios
   githubAccount: alicebits

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -190,7 +190,7 @@ ABCAliceBobbi;
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react-native\\": \\"^0.60.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -10,7 +10,7 @@ Array [
   name: alice-bobbi
   prefix: ABC
   modulePrefix: react-native
-  minimumReactNativeVersion: 0.59.0-rc.0
+  minimumReactNativeVersion: 0.60.0
   packageIdentifier: com.alicebits
   platforms: android,ios
   githubAccount: alicebits
@@ -187,7 +187,7 @@ ABCAliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -820,11 +820,11 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   Object {
     "info": Array [
-      "CREATE example app with the following command: react-native init example --version react-native@0.59",
+      "CREATE example app with the following command: react-native init example --version react-native@latest",
     ],
   },
   Object {
-    "commandSync": "react-native init example --version react-native@0.59",
+    "commandSync": "react-native init example --version react-native@latest",
     "options": Object {
       "cwd": "./react-native-alice-bobbi",
       "stdio": "inherit",

--- a/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
@@ -116,7 +116,7 @@ AliceBobbi;
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\",
+    \\"react-native\\": \\"^0.60.5\\",
     \\"react-native-windows\\": \\"^0.59.0-rc.1\\"
   }
 }

--- a/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
@@ -111,7 +111,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\",
+    \\"react-native\\": \\">=0.60.0 <1.0.x\\",
     \\"react-native-windows\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {


### PR DESCRIPTION
with additional changes that I think are needed to support this update:

- change default exampleReactNativeVersion to react-native@latest
- new `--minimum-react-native-version` configuration option
- react-native@0.60 update in generated devDependencies
- add a note to README.md that these changes break Windows platform support in multiple places

some remaining TODO items:

- [ ] split the additional changes into one or more separate PRs
- [ ] the "default" react-native version in devDependencies should have its own option (and I think that this tool should use this "default" react-native version in the generated example if no `--example-react-native-version` is specified)
- [ ] update tests to test with non-default react-native versions
- [ ] document that React Native 0.59 is still needed for Windows
- [ ] end-to-end testing with example apps on Android & iOS
- [ ] _I think we should find a way to automate the `pod install` step for iOS on React Native 0.60(+), which seems to be done by react-native itself_

Status: DRAFT under discussion, for future consideration