### PR TITLE
[...] refactor stand-alone build definitions in android/build.gradle (generated artifact)

### DIFF
--- a/templates/android.js
+++ b/templates/android.js
@@ -2,7 +2,7 @@ module.exports = platform => [{
   name: () => `${platform}/build.gradle`,
   content: ({ packageIdentifier }) => `// ${platform}/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -18,7 +18,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/templates/android.js
+++ b/templates/android.js
@@ -5,6 +5,8 @@ module.exports = platform => [{
 project.logger.lifecycle('** defining STANDALONE_BUILD_TOOLS_CLASSPATH')
 def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
+def isStandalone = (project == rootProject)
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -14,7 +16,7 @@ buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
     // This avoids unnecessary downloads and potential conflicts when the library is included as a
     // module dependency in an application project.
-    if (project == rootProject) {
+    if (isStandalone) {
         repositories {
             google()
             jcenter()

--- a/templates/android.js
+++ b/templates/android.js
@@ -2,6 +2,8 @@ module.exports = platform => [{
   name: () => `${platform}/build.gradle`,
   content: ({ packageIdentifier }) => `// ${platform}/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -16,7 +18,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/templates/android.js
+++ b/templates/android.js
@@ -2,6 +2,7 @@ module.exports = platform => [{
   name: () => `${platform}/build.gradle`,
   content: ({ packageIdentifier }) => `// ${platform}/build.gradle
 
+project.logger.lifecycle('** defining STANDALONE_BUILD_TOOLS_CLASSPATH')
 def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
@@ -9,6 +10,7 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
+    project.logger.lifecycle('** starting buildscript for stand-alone')
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
     // This avoids unnecessary downloads and potential conflicts when the library is included as a
     // module dependency in an application project.

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -126,7 +126,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
     "name": "react-native-integration-view-test-package/android/build.gradle",
     "theContent": "// android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -142,7 +142,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -126,6 +126,8 @@ sdk.dir=/Users/{username}/Library/Android/sdk
     "name": "react-native-integration-view-test-package/android/build.gradle",
     "theContent": "// android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -140,7 +142,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -126,7 +126,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
     "name": "react-native-integration-test-package/android/build.gradle",
     "theContent": "// android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -142,7 +142,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -126,6 +126,8 @@ sdk.dir=/Users/{username}/Library/Android/sdk
     "name": "react-native-integration-test-package/android/build.gradle",
     "theContent": "// android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -140,7 +142,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -201,7 +201,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -217,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -201,6 +201,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -215,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -206,7 +206,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -222,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -206,6 +206,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -220,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -206,7 +206,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -222,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -206,6 +206,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -220,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -163,6 +163,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -177,7 +179,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -163,7 +163,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -179,7 +179,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -201,7 +201,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -217,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -201,6 +201,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -215,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -206,7 +206,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -222,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -206,6 +206,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -220,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -206,7 +206,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -222,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -206,6 +206,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -220,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -206,7 +206,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -222,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -206,6 +206,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -220,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -206,7 +206,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -222,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -206,6 +206,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -220,7 +222,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -201,7 +201,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -217,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -201,6 +201,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -215,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -163,6 +163,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -177,7 +179,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -163,7 +163,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -179,7 +179,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -201,7 +201,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -217,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -201,6 +201,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -215,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -201,7 +201,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -217,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -201,6 +201,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -215,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -201,7 +201,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -217,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -201,6 +201,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -215,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -201,7 +201,7 @@ content:
 --------
 // android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -217,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -201,6 +201,8 @@ content:
 --------
 // android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -215,7 +217,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -205,7 +205,7 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -221,7 +221,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -205,6 +205,8 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -219,7 +221,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -328,6 +328,8 @@ buck-out/
     "outputFileName": "react-native-test-package/android/build.gradle",
     "theContent": "// android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -342,7 +344,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -328,7 +328,7 @@ buck-out/
     "outputFileName": "react-native-test-package/android/build.gradle",
     "theContent": "// android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -344,7 +344,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -270,6 +270,8 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -284,7 +286,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -270,7 +270,7 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -286,7 +286,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -270,6 +270,8 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -284,7 +286,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -270,7 +270,7 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -286,7 +286,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -270,6 +270,8 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -284,7 +286,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -270,7 +270,7 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -286,7 +286,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -264,7 +264,7 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
-def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+def STANDALONE_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -280,7 +280,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
+            classpath(STANDALONE_BUILD_TOOLS_CLASSPATH)
         }
     }
 }

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -264,6 +264,8 @@ buck-out/
     "outputFileName": "react-native-alice-bobbi/android/build.gradle",
     "theContent": "// android/build.gradle
 
+def ANDROID_BUILD_TOOLS_CLASSPATH = 'com.android.tools.build:gradle:3.4.1'
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -278,7 +280,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath(ANDROID_BUILD_TOOLS_CLASSPATH)
         }
     }
 }


### PR DESCRIPTION
### What

* define Android build tools classpath constant, near the beginning of generated `android/build.gradle`
* rename the new constant in a FIX-UP commit TO BE SQUASHED before or when merging
* add TEMPORARY logging statements *for testing purposes only*
* explicitly define `isStandalone` in the beginning of generated `android/build.gradle`

in followup to updates from PRs #135, #140, and #141

### Status

Attempt to build and run example on Android fails with the following output:

```
Build file '/Users/brodybits/dev/create-react-native-module/cc-788F9A47-CA77-4C23-8CDD-D9561C063828/react-native-bbb/example/node_modules/react-native-bbb/android/build.gradle' line: 17

* What went wrong:
A problem occurred evaluating project ':react-native-bbb'.
> Could not get unknown property 'isStandalone' for object of type org.gradle.api.internal.initialization.DefaultScriptHandler.
```

If I would test at 636cec6e596cd781d5d5395f98204c49c4c010f9, with the TEMPORARY logging statements but no explicit definition of `isStandalone`, the following log output is interesting:

```
> Configure project :react-native-aaa
** starting buildscript for stand-alone
** defining STANDALONE_BUILD_TOOLS_CLASSPATH
```

This output indicates to me that the `buildscript` block with the stand-alone build support is executed before any of the initial `def` items.

At this time I do not understand this. Any help would be much appreciated.

### TODO items

- [ ] resolve the issue described above, so that it may be possible to define the standalone items in the beginning as proposed here
- [ ] remove the TEMPORARY logging statements
- [ ] update the tests
- [ ] squash down to 1 or 2 commits before or during the merge

/cc @friederbluemle @SaeedZhiany