### PR TITLE
cleanup manual installation doc for Android

### DIFF
--- a/templates/general.js
+++ b/templates/general.js
@@ -22,14 +22,14 @@ module.exports = [{
   - Add \`import ${packageIdentifier}.${name}Package;\` to the imports at the top of the file
   - Add \`new ${name}Package()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':${moduleName}'
-  	project(':${moduleName}').projectDir = new File(rootProject.projectDir, 	'../node_modules/${moduleName}/android')
-  	\`\`\`
+	\`\`\`
+	include ':${moduleName}'
+	project(':${moduleName}').projectDir = new File(rootProject.projectDir, '../node_modules/${moduleName}/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':${moduleName}')
-  	\`\`\`
+	\`\`\`
 `;
     }
 

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -85,14 +85,14 @@ buck-out/
   - Add \`import com.reactlibrary.IntegrationViewTestPackagePackage;\` to the imports at the top of the file
   - Add \`new IntegrationViewTestPackagePackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-integration-view-test-package'
-  	project(':react-native-integration-view-test-package').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-integration-view-test-package/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-integration-view-test-package'
+	project(':react-native-integration-view-test-package').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-integration-view-test-package/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-integration-view-test-package')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -85,14 +85,14 @@ buck-out/
   - Add \`import com.reactlibrary.IntegrationTestPackagePackage;\` to the imports at the top of the file
   - Add \`new IntegrationTestPackagePackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-integration-test-package'
-  	project(':react-native-integration-test-package').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-integration-test-package/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-integration-test-package'
+	project(':react-native-integration-test-package').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-integration-test-package/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-integration-test-package')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -65,14 +65,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -69,14 +69,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -69,14 +69,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -48,14 +48,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -65,14 +65,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -69,14 +69,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -69,14 +69,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -69,14 +69,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -69,14 +69,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -65,14 +65,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -48,14 +48,14 @@ content:
   - Add \`import com.alicebits.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -65,14 +65,14 @@ content:
   - Add \`import com.reactlibrary.ABCAliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new ABCAliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -65,14 +65,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -65,14 +65,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':custom-native-alice-bobbi'
-  	project(':custom-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/custom-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':custom-native-alice-bobbi'
+	project(':custom-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/custom-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':custom-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -65,14 +65,14 @@ content:
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':custom-native-module'
-  	project(':custom-native-module').projectDir = new File(rootProject.projectDir, 	'../node_modules/custom-native-module/android')
-  	\`\`\`
+	\`\`\`
+	include ':custom-native-module'
+	project(':custom-native-module').projectDir = new File(rootProject.projectDir, '../node_modules/custom-native-module/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':custom-native-module')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -81,14 +81,14 @@ Array [
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -225,14 +225,14 @@ Array [
   - Add \`import com.reactlibrary.TestPackagePackage;\` to the imports at the top of the file
   - Add \`new TestPackagePackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-test-package'
-  	project(':react-native-test-package').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-test-package/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-test-package'
+	project(':react-native-test-package').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-test-package/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-test-package')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -145,14 +145,14 @@ Array [
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -145,14 +145,14 @@ Array [
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -145,14 +145,14 @@ Array [
   - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -139,14 +139,14 @@ Array [
   - Add \`import com.alicebits.ABCAliceBobbiPackage;\` to the imports at the top of the file
   - Add \`new ABCAliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
+	\`\`\`
+	include ':react-native-alice-bobbi'
+	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-alice-bobbi/android')
+	\`\`\`
 3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
+	\`\`\`
       compile project(':react-native-alice-bobbi')
-  	\`\`\`
+	\`\`\`
 
 
 ## Usage


### PR DESCRIPTION
### What

cleanup manual installation doc for Android, as generated from `templates/general.js`

* [x] remove spaces that come before tabs
* [ ] anything else?

### Testing

* [x] `npm t` succeeds
* [ ] Travis CI