### PR TITLE
mandatory default package identifier for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Options:
   --prefix <prefix>                         The prefix for the library module (Default: ``)
   --module-name <moduleName>                The module library package name to be used in package.json. Default: react-native-(name in param-case)
   --module-prefix <modulePrefix>            The module prefix for the library module, ignored if --module-name is specified (Default: `react-native`)
-  --package-identifier <packageIdentifier>  (Android only!) The package name for the Android module (Default: `com.reactlibrary`)
+  --package-identifier <packageIdentifier>  (Android only!) The package name for the Android module (Default: ``)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
   --github-account <githubAccount>          The github account where the library module is hosted (Default: `github_account`)
   --author-name <authorName>                The author's name (Default: `Your Name`)
@@ -129,7 +129,7 @@ createLibraryModule({
   moduleName: String, /* The module library package name to be used in package.json. Default: react-native-(name in param-case) */
   modulePrefix: String, /* The module prefix for the library, ignored if moduleName is specified (Default: react-native) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
-  packageIdentifier: String, /* (Android only!) The package name for the Android module (Default: com.reactlibrary) */
+  packageIdentifier: String, /* (Android only!) The package name for the Android module (Default: ``) */
   githubAccount: String, /* The github account where the library is hosted (Default: `github_account`) */
   authorName: String, /* The author's name (Default: `Your Name`) */
   authorEmail: String, /* The author's email (Default: `yourname@email.com`) */

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -70,7 +70,7 @@ ${postCreateInstructions(createOptions)}`);
   }, {
     command: '--package-identifier [packageIdentifier]',
     description: '(Android only!) The package name for the Android module',
-    default: 'com.reactlibrary',
+    default: ``
   }, {
     command: '--platforms <platforms>',
     description: 'Platforms the library module will be created for - comma separated',

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -21,7 +21,7 @@ const normalizedOptions = require('./normalized-options');
 const templates = require('../templates');
 const exampleTemplates = require('../templates/example');
 
-const DEFAULT_PACKAGE_IDENTIFIER = 'com.reactlibrary';
+const DEFAULT_PACKAGE_IDENTIFIER = ``;
 const DEFAULT_PLATFORMS = ['android', 'ios'];
 const DEFAULT_GITHUB_ACCOUNT = 'github_account';
 const DEFAULT_AUTHOR_NAME = 'Your Name';
@@ -83,9 +83,10 @@ const generateWithNormalizedOptions = ({
   fs = fsExtra, // (this can be mocked out for testing purposes)
   execa = execaDefault, // (this can be mocked out for testing purposes)
 }) => {
-  if (packageIdentifier === DEFAULT_PACKAGE_IDENTIFIER) {
-    console.warn(`While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
-      identifier, it is recommended to customize the package identifier.`);
+  if (!!platforms.indexOf('android') && !packageIdentifier) {
+    const message = `CREATE ERROR: no package identifier specified for Android`;
+    console.error(message);
+    throw new Error(message);
   }
 
   // Note that the some of these console log messages are done as


### PR DESCRIPTION
with blank default package identifier

followup item for PR #153 - add `native` item with package ID to package.json

Note that this proposal is using back-ticks instead of single quotes. I think this is a little more proper for templating in general.

TODO items:

- [ ] fix Android package identifier description text (PR #155)
- [ ] test CLI with this update
- [ ] update test suite