### PR TITLE
CLI command function test fixes

### DIFF
--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -37,5 +37,133 @@ Array [
   Object {
     "ensureDir": "react-native-alice-bobbi",
   },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/README.md",
+    "theContent": "# react-native-alice-bobbi
+
+## Getting started
+
+\`$ npm install react-native-alice-bobbi --save\`
+
+### Mostly automatic installation
+
+\`$ react-native link react-native-alice-bobbi\`
+
+### Manual installation
+
+
+
+## Usage
+\`\`\`javascript
+import AliceBobbi from 'react-native-alice-bobbi';
+
+// TODO: What to do with the module?
+AliceBobbi;
+\`\`\`
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/package.json",
+    "theContent": "{
+  \\"name\\": \\"react-native-alice-bobbi\\",
+  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"TODO\\",
+  \\"main\\": \\"index.js\\",
+  \\"scripts\\": {
+    \\"test\\": \\"echo \\\\\\"Error: no test specified\\\\\\" && exit 1\\"
+  },
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  },
+  \\"keywords\\": [
+    \\"react-native\\"
+  ],
+  \\"author\\": {
+    \\"name\\": \\"Your Name\\",
+    \\"email\\": \\"yourname@email.com\\"
+  },
+  \\"license\\": \\"MIT\\",
+  \\"licenseFilename\\": \\"LICENSE\\",
+  \\"readmeFilename\\": \\"README.md\\",
+  \\"peerDependencies\\": {
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+  },
+  \\"devDependencies\\": {
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
+  }
+}
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/index.js",
+    "theContent": "import { NativeModules } from 'react-native';
+
+const { AliceBobbi } = NativeModules;
+
+export default AliceBobbi;
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "theContent": "# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "theContent": "",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "theContent": "",
+  },
+  Object {
+    "log": Array [
+      "
+📚  Created library module react-native-alice-bobbi in \`./react-native-alice-bobbi\`.
+🕘  It took XXX.
+
+====================================================
+YOU'RE ALL SET!
+
+To build and run iOS example project, do:
+----
+cd react-native-alice-bobbi/undefined
+yarn
+react-native run-ios
+----
+",
+    ],
+  },
 ]
 `;

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/cli-command-with-bogus-platforms-name.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/cli-command-with-bogus-platforms-name.test.js
@@ -5,11 +5,14 @@ const mysnap = [];
 const mockpushit = x => mysnap.push(x);
 jest.mock('fs-extra', () => ({
   outputFile: (outputFileName, theContent) => {
-    mockpushit({ outputFileName, theContent });
+    mockpushit({
+      outputFileName: outputFileName.replace(/\\/g, '/'),
+      theContent
+    });
     return Promise.resolve();
   },
   ensureDir: (dir) => {
-    mockpushit({ ensureDir: dir });
+    mockpushit({ ensureDir: dir.replace(/\\/g, '/') });
     return Promise.resolve();
   },
 }));
@@ -20,7 +23,10 @@ global.console = {
     mockpushit({ info: [].concat(args) });
   },
   log: (...args) => {
-    mockpushit({ log: [].concat(args) });
+    mockpushit({
+      // TBD EXTRA WORKAROUND HACK for non-deterministic elapsed time in log
+      log: args.map(line => line.replace(/It took.*s/g, 'It took XXX'))
+    });
   },
   warn: (...args) => {
     mockpushit({ warn: [].concat(args) });
@@ -33,6 +39,12 @@ test(`create alice-bobbi module with logging, with platforms: 'bogus'`, async ()
   const options = { platforms: 'bogus' };
 
   func(args, null, options);
+
+  // Using a 1 ms timer to wait for the
+  // CLI command function to finish.
+  // FUTURE TBD this looks like a bad smell
+  // that should be resolved someday.
+  await new Promise((resolve) => setTimeout(resolve, 1));
 
   expect(mysnap).toMatchSnapshot();
 });

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -37,5 +37,133 @@ Array [
   Object {
     "ensureDir": "react-native-alice-bobbi",
   },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi/",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/README.md",
+    "theContent": "# react-native-alice-bobbi
+
+## Getting started
+
+\`$ npm install react-native-alice-bobbi --save\`
+
+### Mostly automatic installation
+
+\`$ react-native link react-native-alice-bobbi\`
+
+### Manual installation
+
+
+
+## Usage
+\`\`\`javascript
+import AliceBobbi from 'react-native-alice-bobbi';
+
+// TODO: What to do with the module?
+AliceBobbi;
+\`\`\`
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/package.json",
+    "theContent": "{
+  \\"name\\": \\"react-native-alice-bobbi\\",
+  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"TODO\\",
+  \\"main\\": \\"index.js\\",
+  \\"scripts\\": {
+    \\"test\\": \\"echo \\\\\\"Error: no test specified\\\\\\" && exit 1\\"
+  },
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  },
+  \\"keywords\\": [
+    \\"react-native\\"
+  ],
+  \\"author\\": {
+    \\"name\\": \\"Your Name\\",
+    \\"email\\": \\"yourname@email.com\\"
+  },
+  \\"license\\": \\"MIT\\",
+  \\"licenseFilename\\": \\"LICENSE\\",
+  \\"readmeFilename\\": \\"README.md\\",
+  \\"peerDependencies\\": {
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+  },
+  \\"devDependencies\\": {
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
+  }
+}
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/index.js",
+    "theContent": "import { NativeModules } from 'react-native';
+
+const { AliceBobbi } = NativeModules;
+
+export default AliceBobbi;
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "theContent": "# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "theContent": "",
+  },
+  Object {
+    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "theContent": "",
+  },
+  Object {
+    "log": Array [
+      "
+📚  Created library module react-native-alice-bobbi in \`./react-native-alice-bobbi\`.
+🕘  It took XXX.
+
+====================================================
+YOU'RE ALL SET!
+
+To build and run iOS example project, do:
+----
+cd react-native-alice-bobbi/undefined
+yarn
+react-native run-ios
+----
+",
+    ],
+  },
 ]
 `;

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/cli-command-with-empty-platforms-string.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/cli-command-with-empty-platforms-string.test.js
@@ -23,7 +23,10 @@ global.console = {
     mockpushit({ info: [].concat(args) });
   },
   log: (...args) => {
-    mockpushit({ log: [].concat(args) });
+    mockpushit({
+      // TBD EXTRA WORKAROUND HACK for non-deterministic elapsed time in log
+      log: args.map(line => line.replace(/It took.*s/g, 'It took XXX'))
+    });
   },
   warn: (...args) => {
     mockpushit({ warn: [].concat(args) });
@@ -36,6 +39,12 @@ test(`create alice-bobbi module with logging, with platforms: ''`, async () => {
   const options = { platforms: '' };
 
   func(args, null, options);
+
+  // Using a 1 ms timer to wait for the
+  // CLI command function to finish.
+  // FUTURE TBD this looks like a bad smell
+  // that should be resolved someday.
+  await new Promise((resolve) => setTimeout(resolve, 1));
 
   expect(mysnap).toMatchSnapshot();
 });


### PR DESCRIPTION
for tests with bogus values of `platforms`

* use internal 1ms timer to give CLI func output time to finish & update the affected snapshots
* use a string replace WORKAROUND HACK to work around indeterminate elapsed time in the log
* test updates for Windows

These tests now cover *most* of the CLI function log output.