### PR TITLE
fix async CLI func tests again

### DIFF
--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/cli-command-with-bogus-platforms-name.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/cli-command-with-bogus-platforms-name.test.js
@@ -38,13 +38,7 @@ test(`create alice-bobbi module with logging, with platforms: 'bogus'`, async ()
 
   const options = { platforms: 'bogus' };
 
-  func(args, null, options);
-
-  // Using a 1 ms timer to wait for the
-  // CLI command function to finish.
-  // FUTURE TBD this looks like a bad smell
-  // that should be resolved someday.
-  await new Promise((resolve) => setTimeout(resolve, 1));
+  await func(args, null, options);
 
   expect(mysnap).toMatchSnapshot();
 });

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/cli-command-with-empty-platforms-string.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/cli-command-with-empty-platforms-string.test.js
@@ -38,13 +38,7 @@ test(`create alice-bobbi module with logging, with platforms: ''`, async () => {
 
   const options = { platforms: '' };
 
-  func(args, null, options);
-
-  // Using a 1 ms timer to wait for the
-  // CLI command function to finish.
-  // FUTURE TBD this looks like a bad smell
-  // that should be resolved someday.
-  await new Promise((resolve) => setTimeout(resolve, 1));
+  await func(args, null, options);
 
   expect(mysnap).toMatchSnapshot();
 });


### PR DESCRIPTION
simply do `await func(...)` rather than waiting for a 1ms timer