### PR TITLE
test CLI command func error with logging

### DIFF
--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create alice-bobbi module with logging, with fs error (with defaults for Android & iOS) 1`] = `
+Array [
+  Object {
+    "warn": Array [
+      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      identifier, it is recommended to customize the package identifier.",
+    ],
+  },
+  Object {
+    "info": Array [
+      "CREATE new React Native module with the following options:
+
+  root moduleName: react-native-alice-bobbi
+  name: alice-bobbi
+  prefix: 
+  modulePrefix: react-native
+  packageIdentifier: com.reactlibrary
+  platforms: android,ios
+  githubAccount: github_account
+  authorName: Your Name
+  authorEmail: yourname@email.com
+  license: MIT
+  view: false
+  useCocoapods: false
+  generateExample: false
+  exampleName: example
+  ",
+    ],
+  },
+  Object {
+    "info": Array [
+      "CREATE: Generating the React Native library module",
+    ],
+  },
+  Object {
+    "ensureDir": "react-native-alice-bobbi",
+  },
+  Object {
+    "error": Array [
+      "Error while creating library module react-native-alice-bobbi",
+    ],
+  },
+  Object {
+    "error": Array [
+      "Error: ENOPERM not permitted
+    at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
+    at ensureDir (.../lib/lib.js:147:15)
+    at generateLibraryModule (.../lib/lib.js:240:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:257:10)
+    at createLibraryModule (.../lib/cli-command.js:...
+    at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
+    ",
+    ],
+  },
+]
+`;

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js
@@ -1,0 +1,65 @@
+const func = require('../../../../../../../lib/cli-command.js').func;
+
+// special compact mocks for this test:
+const mysnap = [];
+const mockpushit = x => mysnap.push(x);
+jest.mock('fs-extra', () => ({
+  ensureDir: (dir) => {
+    mockpushit({ ensureDir: dir });
+    return Promise.reject(new Error(`ENOPERM not permitted`));
+  },
+  outputFile: (outputFileName, theContent) => {
+    // NOT EXPECTED:
+    mockpushit({ outputFileName, theContent });
+    return Promise.reject(new Error(`ENOPERM not permitted`));
+  },
+}));
+
+// TBD hackish mock:
+global.console = {
+  info: (...args) => {
+    mockpushit({ info: [].concat(args) });
+  },
+  log: (...args) => {
+    mockpushit({
+      // TBD EXTRA WORKAROUND HACK for non-deterministic elapsed time in log
+      log: args.map(line => line.replace(/It took.*s/g, 'It took XXX'))
+    });
+  },
+  warn: (...args) => {
+    mockpushit({ warn: [].concat(args) });
+  },
+  error: (first, ...rest) => {
+    mockpushit({
+      error: [].concat(
+        [].concat(
+          first
+            // Check trace with relative path
+            // THANKS for guidance:
+            // * https://stackoverflow.com/questions/1144783/how-to-replace-all-occurrences-of-a-string/1145525#1145525
+            // * https://github.com/tunnckoCore/clean-stacktrace-relative-paths/blob/v1.0.4/index.js#L59
+            .split(process.cwd()).join('...')
+            // IGNORE test-dependant trace info
+            .split(/at.*JestTest/)[0]
+            // IGNORE line number in cli-command.js
+            // in order to avoid sensitivity to mutation testing
+            // (miss potentially surviving mutants)
+            .replace(/cli-command.js:.*/, 'cli-command.js:...')
+            // WORKAROUND for Windows:
+            .replace(/\\/g, '/')
+        ),
+        rest
+      )
+    });
+  },
+};
+
+test('create alice-bobbi module with logging, with fs error (with defaults for Android & iOS)', async () => {
+  const args = ['alice-bobbi'];
+
+  const config = 'bogus';
+
+  await func(args, config, {});
+
+  expect(mysnap).toMatchSnapshot();
+});


### PR DESCRIPTION
for coverage of some error logging code in `lib/cli-command.js`

This test case comes from test updates originally proposed in PR #102, with an extra workaround hack due to non-deterministic elapsed time.