### PR TITLE
[...] functional improvements & cleanup in `lib/lib.js`

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -40,7 +40,9 @@ const renderTemplateIfValid = (fs, root, template, templateArgs) => {
   const filename = path.join(root, name);
   const [baseDir] = filename.split(path.basename(filename));
 
-  return fs.ensureDir(baseDir).then(() =>
+  return Promise.resolve().then(() =>
+    fs.ensureDir(baseDir)
+  ).then(() =>
     fs.outputFile(filename, template.content(templateArgs))
   );
 };
@@ -115,7 +117,7 @@ const generateWithNormalizedOptions = ({
   // mockable execa object for now (at least):
   const commandSync = execa.commandSync;
 
-  if (generateExample) {
+  const checkToolsForExampleApp = () => {
     const reactNativeVersionCommand = 'react-native --version';
     const yarnVersionCommand = 'yarn --version';
 
@@ -124,7 +126,9 @@ const generateWithNormalizedOptions = ({
 
     try {
       console.info('CREATE: Check for valid react-native-cli tool version, as needed to generate the example project');
+
       commandSync(reactNativeVersionCommand, checkCliOptions);
+
       console.info(`${reactNativeVersionCommand} ok`);
     } catch (e) {
       throw new Error(
@@ -133,24 +137,24 @@ const generateWithNormalizedOptions = ({
 
     try {
       console.info('CREATE: Check for valid Yarn CLI tool version, as needed to generate the example project');
+
       commandSync(yarnVersionCommand, checkCliOptions);
+
       console.info(`${yarnVersionCommand} ok`);
     } catch (e) {
       throw new Error(
         `${yarnVersionCommand} failed; ${errorRemedyMessage}`);
     }
-  }
-
-  console.info('CREATE: Generating the React Native library module');
+  };
 
   const generateLibraryModule = () => {
+    console.info('CREATE: Generating the React Native library module');
+
     return fs.ensureDir(moduleName).then(() => {
       return Promise.all(templates.filter((template) => {
-        if (template.platform) {
-          return (platforms.indexOf(template.platform) >= 0);
-        }
-
-        return true;
+        return (template.platform
+          ? platforms.indexOf(template.platform) >= 0
+          : true);
       }).map((template) => {
         const templateArgs = {
           name: className,
@@ -180,12 +184,13 @@ const generateWithNormalizedOptions = ({
       const exampleReactNativeInitCommand =
         `react-native init ${exampleName} --version ${exampleReactNativeVersion}`;
 
-      console.info(
-        `CREATE example app with the following command: ${exampleReactNativeInitCommand}`);
-
       const execOptions = { cwd: `./${moduleName}`, stdio: 'inherit' };
 
-      // (with the work done in a promise chain)
+      console.info(
+        `CREATE example app with the following command: ` +
+        exampleReactNativeInitCommand);
+
+      // (with the work done in a *nested* promise chain, for now at least)
       return Promise.resolve()
         .then(() => {
           // We use synchronous execSync / commandSync call here
@@ -211,16 +216,17 @@ const generateWithNormalizedOptions = ({
           );
         })
         .then(() => {
-          // Adds and link the new library
-          return new Promise((resolve, reject) => {
+          // Adds and link the new library,
+          // with the required postinstall script
+          const pathExampleApp = `./${moduleName}/${exampleName}`;
+          return Promise.resolve().then(() => {
             // Add postinstall script to the example package.json
             console.info('Adding cleanup postinstall task to the example app');
-            const pathExampleApp = `./${moduleName}/${exampleName}`;
             npmAddScriptSync(`${pathExampleApp}/package.json`, {
               key: 'postinstall',
               value: `node ../scripts/examples_postinstall.js`
             }, fs);
-
+          }).then(() => {
             // Add and link the new library
             console.info('Linking the new module library to the example app');
             const addLinkLibraryOptions = { cwd: pathExampleApp, stdio: 'inherit' };
@@ -231,18 +237,17 @@ const generateWithNormalizedOptions = ({
               throw (e);
             }
             commandSync('react-native link', addLinkLibraryOptions);
-
-            return resolve();
           });
         });
     };
 
-  return generateLibraryModule().then(() => {
-    return (generateExample
-      ? generateExampleApp()
-      : Promise.resolve()
-    );
-  });
+  return Promise.resolve().then(
+    generateExample ? checkToolsForExampleApp : null
+  ).then(
+    generateLibraryModule
+  ).then(
+    generateExample ? generateExampleApp : null
+  );
 };
 
 // lib function that acccepts options argument and optionally

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -46,12 +46,8 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:147:15)
-    at generateLibraryModule (.../lib/lib.js:240:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:257:10)
-    at createLibraryModule (.../lib/cli-command.js:...
-    at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
-    ",
+    at ensureDir (.../lib/lib.js:153:15)
+    at process._tickCallback (internal/process/next_tick.js:68:7)",
     ],
   },
 ]

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js
@@ -39,12 +39,6 @@ global.console = {
             // * https://stackoverflow.com/questions/1144783/how-to-replace-all-occurrences-of-a-string/1145525#1145525
             // * https://github.com/tunnckoCore/clean-stacktrace-relative-paths/blob/v1.0.4/index.js#L59
             .split(process.cwd()).join('...')
-            // IGNORE test-dependant trace info
-            .split(/at.*JestTest/)[0]
-            // IGNORE line number in cli-command.js
-            // in order to avoid sensitivity to mutation testing
-            // (miss potentially surviving mutants)
-            .replace(/cli-command.js:.*/, 'cli-command.js:...')
             // WORKAROUND for Windows:
             .replace(/\\/g, '/')
         ),


### PR DESCRIPTION
as a first step towards using promise pipelines to work more asynchronously

An unintended side-effect is that an exception such an "ENOPERM" permission error would no longer show the original call stack. This is for further investigation, as part of the list below.

with remaining TODO item(s):

- [ ] resolve known CLI function error logging test failure on Travis CI
- [ ] consider how it may be possible to include the original call stack when an exception is thrown (I already have some ideas, which may resolve the error logging test failure at the same time)