### PR TITLE
[BREAKING] replace --use-cocoapods with 2 options

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Options:
   --author-email <authorEmail>              The author's email (Default: `yourname@email.com`)
   --license <license>                       The license type (Default: `MIT`)
   --view                                    Generate the module as a very simple native view component
-  --use-cocoapods                           [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: Use `AFNetworking` dependency as a sample in the podspec; use it from the iOS code & add `ios/Podfile` to generated example
+  --use-apple-networking                    [iOS] Use `AFNetworking` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                        Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name <exampleName>              Name for the example project (default: `example`)
   --example-react-native-version <version>  React Native version for the generated example project (default: `react-native@0.59`)
@@ -134,7 +134,7 @@ createLibraryModule({
   authorName: String, /* The author's name (Default: `Your Name`) */
   authorEmail: String, /* The author's email (Default: `yourname@email.com`) */
   license: String, /* The license type of this library (Default: `MIT`) */
-  useCocoapods: Boolean, /* [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: Use `AFNetworking` dependency as a sample in the podspec; use it from the iOS code & add `ios/Podfile` to generated example (Default: false) */
+  useAppleNetworking: Boolean, /* [iOS] Use `AFNetworking` dependency as a sample in the podspec & use it from the iOS code (Default: false) */
   view: Boolean, /* Generate the module as a very simple native view component (Default: false) */
   generateExample: Boolean, /* Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally (Default: false) */
   exampleName: String, /* Name for the example project (Default: `example`) */

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Options:
   --generate-example                        Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name <exampleName>              Name for the example project (default: `example`)
   --example-react-native-version <version>  React Native version for the generated example project (default: `react-native@0.59`)
+  --write-example-podfile                   [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
   -h, --help                                output usage information
 ```
 
@@ -146,6 +147,7 @@ createLibraryModule({
   generateExample: Boolean, /* Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally (Default: false) */
   exampleName: String, /* Name for the example project (Default: `example`) */
   exampleReactNativeVersion: String, /* React Native version for the generated example project (Default: `react-native@0.59`) */
+  writeExamplePodfile: Boolean, /* [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile (Default: false) */
 }
 ```
 

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -4,7 +4,7 @@ const normalizedOptions = require('./normalized-options');
 
 const createLibraryModule = require('./lib');
 
-const postCreateInstructions = ({ moduleName, useCocoapods, exampleName }) => {
+const postCreateInstructions = ({ moduleName, exampleName }) => {
   return `
 ====================================================
 YOU'RE ALL SET!
@@ -13,11 +13,10 @@ To build and run iOS example project, do:
 ----
 cd ${moduleName}/${exampleName}
 yarn
-${useCocoapods ? `cd ios
+cd ios
 pod install
 cd ..
-`
-    : ``}react-native run-ios
+react-native run-ios
 ----
 `;
 };
@@ -95,8 +94,8 @@ ${postCreateInstructions(createOptions)}`);
     command: '--view',
     description: 'Generate the module as a very simple native view component',
   }, {
-    command: '--use-cocoapods',
-    description: '[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: Use `AFNetworking` dependency as a sample in the podspec; use it from the iOS code & add `ios/Podfile` to generated example',
+    command: '--use-apple-networking',
+    description: '[iOS] Use `AFNetworking` dependency as a sample in the podspec & use it from the iOS code',
   }, {
     command: '--generate-example',
     description: 'Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally',

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -4,7 +4,7 @@ const normalizedOptions = require('./normalized-options');
 
 const createLibraryModule = require('./lib');
 
-const postCreateInstructions = ({ moduleName, exampleName }) => {
+const postCreateInstructions = ({ moduleName, exampleName, writeExamplePodfile }) => {
   return `
 ====================================================
 YOU'RE ALL SET!
@@ -14,7 +14,7 @@ To build and run iOS example project, do:
 cd ${moduleName}/${exampleName}
 yarn
 cd ios
-pod install
+pod install # ${writeExamplePodfile ? `required` : `required starting with React Native 0.60`}
 cd ..
 react-native run-ios
 ----
@@ -110,5 +110,8 @@ ${postCreateInstructions(createOptions)}`);
     command: '--example-react-native-version [exampleReactNativeVersion]',
     description: 'React Native version for the generated example project',
     default: 'react-native@0.59',
+  }, {
+    command: '--write-example-podfile',
+    description: '[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile',
   }]
 };

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -79,6 +79,7 @@ const generateWithNormalizedOptions = ({
   generateExample = DEFAULT_GENERATE_EXAMPLE,
   exampleName = DEFAULT_EXAMPLE_NAME,
   exampleReactNativeVersion = DEFAULT_EXAMPLE_REACT_NATIVE_VERSION,
+  writeExamplePodfile = false,
 }, {
   fs = fsExtra, // (this can be mocked out for testing purposes)
   execa = execaDefault, // (this can be mocked out for testing purposes)
@@ -110,6 +111,7 @@ const generateWithNormalizedOptions = ({
   useAppleNetworking: ${useAppleNetworking}
   generateExample: ${generateExample}
   exampleName: ${exampleName}
+  writeExamplePodfile: ${writeExamplePodfile}
   `);
 
   // QUICK LOCAL INJECTION overwite of existing execSync / commandSync call from
@@ -204,6 +206,7 @@ const generateWithNormalizedOptions = ({
             view,
             useAppleNetworking,
             exampleName,
+            writeExamplePodfile,
           };
 
           return Promise.all(

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -27,7 +27,6 @@ const DEFAULT_GITHUB_ACCOUNT = 'github_account';
 const DEFAULT_AUTHOR_NAME = 'Your Name';
 const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com';
 const DEFAULT_LICENSE = 'MIT';
-const DEFAULT_USE_COCOAPODS = false;
 const DEFAULT_GENERATE_EXAMPLE = false;
 const DEFAULT_EXAMPLE_NAME = 'example';
 const DEFAULT_EXAMPLE_REACT_NATIVE_VERSION = 'react-native@0.59';
@@ -75,7 +74,7 @@ const generateWithNormalizedOptions = ({
   authorEmail = DEFAULT_AUTHOR_EMAIL,
   license = DEFAULT_LICENSE,
   view = false,
-  useCocoapods = DEFAULT_USE_COCOAPODS,
+  useAppleNetworking = false,
   generateExample = DEFAULT_GENERATE_EXAMPLE,
   exampleName = DEFAULT_EXAMPLE_NAME,
   exampleReactNativeVersion = DEFAULT_EXAMPLE_REACT_NATIVE_VERSION,
@@ -106,7 +105,7 @@ const generateWithNormalizedOptions = ({
   authorEmail: ${authorEmail}
   license: ${license}
   view: ${view}
-  useCocoapods: ${useCocoapods}
+  useAppleNetworking: ${useAppleNetworking}
   generateExample: ${generateExample}
   exampleName: ${exampleName}
   `);
@@ -163,7 +162,7 @@ const generateWithNormalizedOptions = ({
           authorEmail,
           license,
           view,
-          useCocoapods,
+          useAppleNetworking,
           generateExample,
           exampleName,
         };
@@ -200,7 +199,7 @@ const generateWithNormalizedOptions = ({
             name: className,
             moduleName,
             view,
-            useCocoapods,
+            useAppleNetworking,
             exampleName,
           };
 

--- a/templates/example.js
+++ b/templates/example.js
@@ -114,41 +114,6 @@ module.exports = [{
   })();
 `
 }, {
-  name: ({ useCocoapods, exampleName }) =>
-    useCocoapods ? `${exampleName}/ios/Podfile` : undefined,
-  content: ({ moduleName, exampleName }) => `platform :ios, '10.0'
-
-	target '${exampleName}' do
-		rn_path = '../node_modules/react-native'
-	
-		pod 'yoga', path: "#{rn_path}/ReactCommon/yoga/yoga.podspec"
-		pod 'DoubleConversion', :podspec => "#{rn_path}/third-party-podspecs/DoubleConversion.podspec"
-		pod 'Folly', :podspec => "#{rn_path}/third-party-podspecs/Folly.podspec"
-		pod 'glog', :podspec => "#{rn_path}/third-party-podspecs/GLog.podspec"
-		pod 'React', path: rn_path, subspecs: [
-			'Core',
-			'CxxBridge',
-			'RCTAnimation',
-			'RCTActionSheet',
-			'RCTImage',
-			'RCTLinkingIOS',
-			'RCTNetwork',
-			'RCTSettings',
-			'RCTText',
-			'RCTVibration',
-			'RCTWebSocket',
-			'RCTPushNotification',
-			'RCTCameraRoll',
-			'RCTSettings',
-			'RCTBlob',
-			'RCTGeolocation',
-			'DevSupport'
-		]
-	
-		pod '${moduleName}', :path => '../../${moduleName}.podspec'
-	end
-`,
-}, {
   name: ({ exampleName }) => `${exampleName}/App.js`,
   content: ({ moduleName, name, view }) =>
     `/**

--- a/templates/example.js
+++ b/templates/example.js
@@ -114,6 +114,41 @@ module.exports = [{
   })();
 `
 }, {
+  name: ({ exampleName, writeExamplePodfile }) =>
+    writeExamplePodfile ? `${exampleName}/ios/Podfile` : undefined,
+  content: ({ moduleName, exampleName }) => `platform :ios, '10.0'
+
+	target '${exampleName}' do
+		rn_path = '../node_modules/react-native'
+
+		pod 'yoga', path: "#{rn_path}/ReactCommon/yoga/yoga.podspec"
+		pod 'DoubleConversion', :podspec => "#{rn_path}/third-party-podspecs/DoubleConversion.podspec"
+		pod 'Folly', :podspec => "#{rn_path}/third-party-podspecs/Folly.podspec"
+		pod 'glog', :podspec => "#{rn_path}/third-party-podspecs/GLog.podspec"
+		pod 'React', path: rn_path, subspecs: [
+			'Core',
+			'CxxBridge',
+			'RCTAnimation',
+			'RCTActionSheet',
+			'RCTImage',
+			'RCTLinkingIOS',
+			'RCTNetwork',
+			'RCTSettings',
+			'RCTText',
+			'RCTVibration',
+			'RCTWebSocket',
+			'RCTPushNotification',
+			'RCTCameraRoll',
+			'RCTSettings',
+			'RCTBlob',
+			'RCTGeolocation',
+			'DevSupport'
+		]
+
+		pod '${moduleName}', :path => '../../${moduleName}.podspec'
+	end
+`,
+}, {
   name: ({ exampleName }) => `${exampleName}/App.js`,
   content: ({ moduleName, name, view }) =>
     `/**

--- a/templates/ios.js
+++ b/templates/ios.js
@@ -1,6 +1,6 @@
 module.exports = platform => [{
   name: ({ moduleName }) => `${moduleName}.podspec`,
-  content: ({ moduleName, githubAccount, authorName, authorEmail, useCocoapods }) => `require "json"
+  content: ({ moduleName, githubAccount, authorName, authorEmail, useAppleNetworking }) => `require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-	${useCocoapods ? `s.dependency 'AFNetworking', '~> 3.0'` : ``}
+	${useAppleNetworking ? `s.dependency 'AFNetworking', '~> 3.0'` : ``}
   # s.dependency "..."
 end
 
@@ -39,9 +39,9 @@ end
 }, {
   // implementation of module without view:
   name: ({ name, view }) => !view && `${platform}/${name}.m`,
-  content: ({ name, useCocoapods }) => `#import "${name}.h"
+  content: ({ name, useAppleNetworking }) => `#import "${name}.h"
 
-${useCocoapods ? `#import <AFNetworking/AFNetworking.h>
+${useAppleNetworking ? `#import <AFNetworking/AFNetworking.h>
 ` : ``}
 @implementation ${name}
 
@@ -50,7 +50,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
 {
     // TODO: Implement some actually useful functionality
-	${useCocoapods
+	${useAppleNetworking
     ? `AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
 	manager.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@"text/plain"];
 	[manager GET:@"https://httpstat.us/200" parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -22,5 +22,6 @@ Options:
   --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name [exampleName]                                Name for the example project (default: \\"example\\")
   --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")
+  --write-example-podfile                                     [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
   -h, --help                                                  output usage information"
 `;

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -17,7 +17,7 @@ Options:
   --author-email [authorEmail]                                The author's email (default: \\"yourname@email.com\\")
   --license [license]                                         The license type (default: \\"MIT\\")
   --view                                                      Generate the module as a very simple native view component
-  --use-cocoapods                                             [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: Use \`AFNetworking\` dependency as a sample in the podspec; use it from the iOS code & add \`ios/Podfile\` to generated example
+  --use-apple-networking                                      [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name [exampleName]                                Name for the example project (default: \\"example\\")
   --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -22,5 +22,6 @@ Options:
   --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name [exampleName]                                Name for the example project (default: \\"example\\")
   --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")
+  --write-example-podfile                                     [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
   -h, --help                                                  output usage information"
 `;

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -17,7 +17,7 @@ Options:
   --author-email [authorEmail]                                The author's email (default: \\"yourname@email.com\\")
   --license [license]                                         The license type (default: \\"MIT\\")
   --view                                                      Generate the module as a very simple native view component
-  --use-cocoapods                                             [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: Use \`AFNetworking\` dependency as a sample in the podspec; use it from the iOS code & add \`ios/Podfile\` to generated example
+  --use-apple-networking                                      [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name [exampleName]                                Name for the example project (default: \\"example\\")
   --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -55,8 +55,8 @@ Object {
       "description": "Generate the module as a very simple native view component",
     },
     Object {
-      "command": "--use-cocoapods",
-      "description": "[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: Use \`AFNetworking\` dependency as a sample in the podspec; use it from the iOS code & add \`ios/Podfile\` to generated example",
+      "command": "--use-apple-networking",
+      "description": "[iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code",
     },
     Object {
       "command": "--generate-example",

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -76,6 +76,10 @@ Object {
       "default": "react-native@0.59",
       "description": "React Native version for the generated example project",
     },
+    Object {
+      "command": "--write-example-podfile",
+      "description": "[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile",
+    },
   ],
   "usage": "[options] <name>",
 }

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -774,6 +774,8 @@ content:
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",
+  "* ensureDir dir: react-native-alice-bobbi/test-demo/ios/
+",
   "* ensureDir dir: react-native-alice-bobbi/test-demo/
 ",
   "* outputFile name: react-native-alice-bobbi/scripts/examples_postinstall.js
@@ -890,6 +892,43 @@ content:
     const npmIgnorePath = path.resolve(__dirname, '../.npmignore');
     removeLibraryNpmIgnorePaths(npmIgnorePath, libraryNodeModulesPath);
   })();
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/test-demo/ios/Podfile
+content:
+--------
+platform :ios, '10.0'
+
+	target 'test-demo' do
+		rn_path = '../node_modules/react-native'
+
+		pod 'yoga', path: \\"#{rn_path}/ReactCommon/yoga/yoga.podspec\\"
+		pod 'DoubleConversion', :podspec => \\"#{rn_path}/third-party-podspecs/DoubleConversion.podspec\\"
+		pod 'Folly', :podspec => \\"#{rn_path}/third-party-podspecs/Folly.podspec\\"
+		pod 'glog', :podspec => \\"#{rn_path}/third-party-podspecs/GLog.podspec\\"
+		pod 'React', path: rn_path, subspecs: [
+			'Core',
+			'CxxBridge',
+			'RCTAnimation',
+			'RCTActionSheet',
+			'RCTImage',
+			'RCTLinkingIOS',
+			'RCTNetwork',
+			'RCTSettings',
+			'RCTText',
+			'RCTVibration',
+			'RCTWebSocket',
+			'RCTPushNotification',
+			'RCTCameraRoll',
+			'RCTSettings',
+			'RCTBlob',
+			'RCTGeolocation',
+			'DevSupport'
+		]
+
+		pod 'react-native-alice-bobbi', :path => '../../react-native-alice-bobbi.podspec'
+	end
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -461,7 +461,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency \\"React\\"
-	s.dependency 'AFNetworking', '~> 3.0'
+	
   # s.dependency \\"...\\"
 end
 
@@ -484,7 +484,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-#import <AFNetworking/AFNetworking.h>
 
 @implementation AliceBobbi
 
@@ -493,13 +492,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
 {
     // TODO: Implement some actually useful functionality
-	AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
-	manager.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@\\"text/plain\\"];
-	[manager GET:@\\"https://httpstat.us/200\\" parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
-			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ resp: %@\\", numberArgument, stringArgument, responseObject]]);
-	} failure:^(NSURLSessionTask *operation, NSError *error) {
-			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ err: %@\\", numberArgument, stringArgument, error]]);
-	}];
+	callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@\\", numberArgument, stringArgument]]);
 }
 
 @end
@@ -800,8 +793,6 @@ content:
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/test-demo/ios/
-",
   "* ensureDir dir: react-native-alice-bobbi/test-demo/
 ",
   "* outputFile name: react-native-alice-bobbi/scripts/examples_postinstall.js
@@ -918,43 +909,6 @@ content:
     const npmIgnorePath = path.resolve(__dirname, '../.npmignore');
     removeLibraryNpmIgnorePaths(npmIgnorePath, libraryNodeModulesPath);
   })();
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/test-demo/ios/Podfile
-content:
---------
-platform :ios, '10.0'
-
-	target 'test-demo' do
-		rn_path = '../node_modules/react-native'
-	
-		pod 'yoga', path: \\"#{rn_path}/ReactCommon/yoga/yoga.podspec\\"
-		pod 'DoubleConversion', :podspec => \\"#{rn_path}/third-party-podspecs/DoubleConversion.podspec\\"
-		pod 'Folly', :podspec => \\"#{rn_path}/third-party-podspecs/Folly.podspec\\"
-		pod 'glog', :podspec => \\"#{rn_path}/third-party-podspecs/GLog.podspec\\"
-		pod 'React', path: rn_path, subspecs: [
-			'Core',
-			'CxxBridge',
-			'RCTAnimation',
-			'RCTActionSheet',
-			'RCTImage',
-			'RCTLinkingIOS',
-			'RCTNetwork',
-			'RCTSettings',
-			'RCTText',
-			'RCTVibration',
-			'RCTWebSocket',
-			'RCTPushNotification',
-			'RCTCameraRoll',
-			'RCTSettings',
-			'RCTBlob',
-			'RCTGeolocation',
-			'DevSupport'
-		]
-	
-		pod 'react-native-alice-bobbi', :path => '../../react-native-alice-bobbi.podspec'
-	end
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -435,7 +435,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency \\"React\\"
-	
+	s.dependency 'AFNetworking', '~> 3.0'
   # s.dependency \\"...\\"
 end
 
@@ -458,6 +458,7 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
+#import <AFNetworking/AFNetworking.h>
 
 @implementation AliceBobbi
 
@@ -466,7 +467,13 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
 {
     // TODO: Implement some actually useful functionality
-	callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@\\", numberArgument, stringArgument]]);
+	AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
+	manager.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@\\"text/plain\\"];
+	[manager GET:@\\"https://httpstat.us/200\\" parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
+			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ resp: %@\\", numberArgument, stringArgument, responseObject]]);
+	} failure:^(NSURLSessionTask *operation, NSError *error) {
+			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ err: %@\\", numberArgument, stringArgument, error]]);
+	}];
 }
 
 @end

--- a/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
+++ b/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
@@ -17,7 +17,7 @@ test('create alice-bobbi module with example, with config options', () => {
     generateExample: true,
     exampleName: 'test-demo',
     exampleReactNativeVersion: 'react-native@0.60',
-    useCocoapods: true
+    useAppleNetworking: true
   };
 
   return lib(options, inject)

--- a/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
+++ b/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
@@ -17,7 +17,8 @@ test('create alice-bobbi module with example, with config options', () => {
     generateExample: true,
     exampleName: 'test-demo',
     exampleReactNativeVersion: 'react-native@0.60',
-    useAppleNetworking: true
+    useAppleNetworking: true,
+    writeExamplePodfile: true,
   };
 
   return lib(options, inject)

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -183,7 +183,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency \\"React\\"
-	s.dependency 'AFNetworking', '~> 3.0'
+	
   # s.dependency \\"...\\"
 end
 
@@ -206,7 +206,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-#import <AFNetworking/AFNetworking.h>
 
 @implementation AliceBobbi
 
@@ -215,13 +214,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
 {
     // TODO: Implement some actually useful functionality
-	AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
-	manager.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@\\"text/plain\\"];
-	[manager GET:@\\"https://httpstat.us/200\\" parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
-			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ resp: %@\\", numberArgument, stringArgument, responseObject]]);
-	} failure:^(NSURLSessionTask *operation, NSError *error) {
-			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ err: %@\\", numberArgument, stringArgument, error]]);
-	}];
+	callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@\\", numberArgument, stringArgument]]);
 }
 
 @end

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -172,7 +172,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency \\"React\\"
-	
+	s.dependency 'AFNetworking', '~> 3.0'
   # s.dependency \\"...\\"
 end
 
@@ -195,6 +195,7 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
+#import <AFNetworking/AFNetworking.h>
 
 @implementation AliceBobbi
 
@@ -203,7 +204,13 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
 {
     // TODO: Implement some actually useful functionality
-	callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@\\", numberArgument, stringArgument]]);
+	AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
+	manager.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@\\"text/plain\\"];
+	[manager GET:@\\"https://httpstat.us/200\\" parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
+			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ resp: %@\\", numberArgument, stringArgument, responseObject]]);
+	} failure:^(NSURLSessionTask *operation, NSError *error) {
+			callback(@[[NSString stringWithFormat: @\\"numberArgument: %@ stringArgument: %@ err: %@\\", numberArgument, stringArgument, error]]);
+	}];
 }
 
 @end

--- a/tests/with-injection/create/with-options/for-ios/create-with-options-for-ios.test.js
+++ b/tests/with-injection/create/with-options/for-ios/create-with-options-for-ios.test.js
@@ -15,7 +15,7 @@ test('create alice-bobbi module with config options for iOS only', () => {
     authorName: 'Alice',
     authorEmail: 'contact@alice.me',
     license: 'ISC',
-    useCocoapods: true
+    useAppleNetworking: true
   };
 
   return lib(options, inject)

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -23,7 +23,7 @@ Array [
   authorEmail: yourname@email.com
   license: MIT
   view: false
-  useCocoapods: false
+  useAppleNetworking: false
   generateExample: false
   exampleName: example
   ",
@@ -160,6 +160,9 @@ To build and run iOS example project, do:
 ----
 cd react-native-alice-bobbi/undefined
 yarn
+cd ios
+pod install
+cd ..
 react-native run-ios
 ----
 ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -27,6 +27,7 @@ Array [
   useAppleNetworking: false
   generateExample: false
   exampleName: example
+  writeExamplePodfile: false
   ",
     ],
   },
@@ -158,7 +159,7 @@ To build and run iOS example project, do:
 cd react-native-alice-bobbi/undefined
 yarn
 cd ios
-pod install
+pod install # required starting with React Native 0.60
 cd ..
 react-native run-ios
 ----

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -23,7 +23,7 @@ Array [
   authorEmail: yourname@email.com
   license: MIT
   view: false
-  useCocoapods: false
+  useAppleNetworking: false
   generateExample: false
   exampleName: example
   ",
@@ -160,6 +160,9 @@ To build and run iOS example project, do:
 ----
 cd react-native-alice-bobbi/undefined
 yarn
+cd ios
+pod install
+cd ..
 react-native run-ios
 ----
 ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -27,6 +27,7 @@ Array [
   useAppleNetworking: false
   generateExample: false
   exampleName: example
+  writeExamplePodfile: false
   ",
     ],
   },
@@ -158,7 +159,7 @@ To build and run iOS example project, do:
 cd react-native-alice-bobbi/undefined
 yarn
 cd ios
-pod install
+pod install # required starting with React Native 0.60
 cd ..
 react-native run-ios
 ----

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -27,6 +27,7 @@ Array [
   useAppleNetworking: false
   generateExample: false
   exampleName: example
+  writeExamplePodfile: false
   ",
     ],
   },
@@ -47,9 +48,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:148:15)
-    at generateLibraryModule (.../lib/lib.js:242:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:259:10)
+    at ensureDir (.../lib/lib.js:150:15)
+    at generateLibraryModule (.../lib/lib.js:245:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:262:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -23,7 +23,7 @@ Array [
   authorEmail: yourname@email.com
   license: MIT
   view: false
-  useCocoapods: false
+  useAppleNetworking: false
   generateExample: false
   exampleName: example
   ",
@@ -46,9 +46,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:147:15)
-    at generateLibraryModule (.../lib/lib.js:240:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:257:10)
+    at ensureDir (.../lib/lib.js:146:15)
+    at generateLibraryModule (.../lib/lib.js:239:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:256:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -122,8 +122,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--use-cocoapods",
-        "[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: Use \`AFNetworking\` dependency as a sample in the podspec; use it from the iOS code & add \`ios/Podfile\` to generated example",
+        "--use-apple-networking",
+        "[iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code",
         [Function],
         undefined,
       ],

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -170,6 +170,16 @@ Array [
     },
   },
   Object {
+    "option": Object {
+      "args": Array [
+        "--write-example-podfile",
+        "[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
     "parse": Object {
       "argv": Array [
         "node",

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -168,6 +168,16 @@ Array [
     },
   },
   Object {
+    "option": Object {
+      "args": Array [
+        "--write-example-podfile",
+        "[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
     "parse": Object {
       "argv": Array [
         "node",

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -120,8 +120,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--use-cocoapods",
-        "[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: Use \`AFNetworking\` dependency as a sample in the podspec; use it from the iOS code & add \`ios/Podfile\` to generated example",
+        "--use-apple-networking",
+        "[iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code",
         [Function],
         undefined,
       ],

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -27,6 +27,7 @@ Array [
   useAppleNetworking: false
   generateExample: true
   exampleName: example
+  writeExamplePodfile: false
   ",
     ],
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -23,7 +23,7 @@ Array [
   authorEmail: yourname@email.com
   license: MIT
   view: false
-  useCocoapods: false
+  useAppleNetworking: false
   generateExample: true
   exampleName: example
   ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -27,6 +27,7 @@ Array [
   useAppleNetworking: false
   generateExample: true
   exampleName: example
+  writeExamplePodfile: false
   ",
     ],
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -23,7 +23,7 @@ Array [
   authorEmail: yourname@email.com
   license: MIT
   view: false
-  useCocoapods: false
+  useAppleNetworking: false
   generateExample: true
   exampleName: example
   ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -27,6 +27,7 @@ Array [
   useAppleNetworking: false
   generateExample: true
   exampleName: example
+  writeExamplePodfile: false
   ",
     ],
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -23,7 +23,7 @@ Array [
   authorEmail: yourname@email.com
   license: MIT
   view: false
-  useCocoapods: false
+  useAppleNetworking: false
   generateExample: true
   exampleName: example
   ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -17,7 +17,7 @@ Array [
   authorEmail: contact@alice.me
   license: ISC
   view: false
-  useCocoapods: false
+  useAppleNetworking: false
   generateExample: true
   exampleName: example
   ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -21,6 +21,7 @@ Array [
   useAppleNetworking: false
   generateExample: true
   exampleName: example
+  writeExamplePodfile: false
   ",
     ],
   },


### PR DESCRIPTION
__replace `--use-cocoapods` with `--use-apple-networking` & `--write-example-podfile`__

* _extra example ios/Podfile is now behind its own *experimental* option flag, with a couple of trailing tabs removed_
* update the final CLI log message to *always* include instructions to do `pod install`, with a comment depending on use of `--write-example-podfile` or not
* with an outdated DEFAULT constant removed, as it is not really needed
* with CLI error logging test snapshot updated (due to the effect of the change on the stack trace)

This proposal should be considered a BREAKING CHANGE, for a 0.x minor release as opposed to a patch release.

This is a followup to PR #166 (update description to match the reality), in response to issue #155.

Resolves #145 (rename `--use-cocoapods` option).

TODO items:

- [ ] update the commit message to include a more clear list of the actual changes, like there are in this description

_For future consideration, **outside** this PR:_

- consider automating the `pod install` part so that this step can be removed from the generated message ref: #99