### PR TITLE
Manual installation gone in generated README.md

### DIFF
--- a/templates/general.js
+++ b/templates/general.js
@@ -1,50 +1,6 @@
 module.exports = [{
   name: () => 'README.md',
   content: ({ moduleName, packageIdentifier, name, namespace, platforms }) => {
-    let manualInstallation = '';
-
-    if (platforms.indexOf('ios') >= 0) {
-      manualInstallation += `
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`${moduleName}\` and add \`${name}.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`lib${name}.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-`;
-    }
-
-    if (platforms.indexOf('android') >= 0) {
-      manualInstallation += `
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import ${packageIdentifier}.${name}Package;\` to the imports at the top of the file
-  - Add \`new ${name}Package()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':${moduleName}'
-  	project(':${moduleName}').projectDir = new File(rootProject.projectDir, 	'../node_modules/${moduleName}/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':${moduleName}')
-  	\`\`\`
-`;
-    }
-
-    if (platforms.indexOf('windows') >= 0) {
-      manualInstallation += `
-#### Windows
-[Read it! :D](https://github.com/ReactWindows/react-native)
-
-1. In Visual Studio add the \`${name}.sln\` in \`node_modules/${moduleName}/windows/${name}.sln\` folder to their solution, reference from their app.
-2. Open up your \`MainPage.cs\` app
-  - Add \`using ${namespace}.${name};\` to the usings at the top of the file
-  - Add \`new ${name}Package()\` to the \`List<IReactPackage>\` returned by the \`Packages\` method
-`;
-    }
-
     return `# ${moduleName}
 
 ## Getting started
@@ -54,10 +10,6 @@ module.exports = [{
 ### Mostly automatic installation
 
 \`$ react-native link ${moduleName}\`
-
-### Manual installation
-
-${manualInstallation}
 
 ## Usage
 \`\`\`javascript

--- a/templates/general.js
+++ b/templates/general.js
@@ -1,7 +1,7 @@
 module.exports = [{
   name: () => 'README.md',
-  content: ({ moduleName, packageIdentifier, name, namespace, platforms }) => {
-    return `# ${moduleName}
+  content: ({ moduleName, name }) =>
+    `# ${moduleName}
 
 ## Getting started
 
@@ -18,8 +18,7 @@ import ${name} from '${moduleName}';
 // TODO: What to do with the module?
 ${name};
 \`\`\`
-`;
-  },
+`,
 }, {
   name: () => 'package.json',
   content: ({ moduleName, platforms, githubAccount, authorName, authorEmail, license }) => {

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -69,32 +69,6 @@ buck-out/
 
 \`$ react-native link react-native-integration-view-test-package\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-integration-view-test-package\` and add \`IntegrationViewTestPackage.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libIntegrationViewTestPackage.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.IntegrationViewTestPackagePackage;\` to the imports at the top of the file
-  - Add \`new IntegrationViewTestPackagePackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-integration-view-test-package'
-  	project(':react-native-integration-view-test-package').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-integration-view-test-package/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-integration-view-test-package')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import IntegrationViewTestPackage from 'react-native-integration-view-test-package';

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -69,32 +69,6 @@ buck-out/
 
 \`$ react-native link react-native-integration-test-package\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-integration-test-package\` and add \`IntegrationTestPackage.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libIntegrationTestPackage.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.IntegrationTestPackagePackage;\` to the imports at the top of the file
-  - Add \`new IntegrationTestPackagePackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-integration-test-package'
-  	project(':react-native-integration-test-package').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-integration-test-package/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-integration-test-package')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import IntegrationTestPackage from 'react-native-integration-test-package';

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -49,32 +49,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -53,32 +53,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -53,32 +53,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -39,25 +39,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
@@ -39,17 +39,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -49,32 +49,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
@@ -29,10 +29,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
@@ -29,10 +29,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
@@ -29,10 +29,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -53,32 +53,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -53,32 +53,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -53,32 +53,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -53,32 +53,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -49,32 +49,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -39,25 +39,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.alicebits.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -39,17 +39,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -49,32 +49,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`ABCAliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libABCAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.ABCAliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new ABCAliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import ABCAliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -49,32 +49,6 @@ content:
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -49,32 +49,6 @@ content:
 
 \`$ react-native link custom-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`custom-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':custom-native-alice-bobbi'
-  	project(':custom-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/custom-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':custom-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'custom-native-alice-bobbi';

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -49,32 +49,6 @@ content:
 
 \`$ react-native link custom-native-module\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`custom-native-module\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':custom-native-module'
-  	project(':custom-native-module').projectDir = new File(rootProject.projectDir, 	'../node_modules/custom-native-module/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':custom-native-module')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'custom-native-module';

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -67,10 +67,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -67,10 +67,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -65,32 +65,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -216,25 +216,6 @@ Array [
 
 \`$ react-native link react-native-test-package\`
 
-### Manual installation
-
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.TestPackagePackage;\` to the imports at the top of the file
-  - Add \`new TestPackagePackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-test-package'
-  	project(':react-native-test-package').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-test-package/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-test-package')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import TestPackage from 'react-native-test-package';

--- a/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
@@ -62,18 +62,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### Windows
-[Read it! :D](https://github.com/ReactWindows/react-native)
-
-1. In Visual Studio add the \`AliceBobbi.sln\` in \`node_modules/react-native-alice-bobbi/windows/AliceBobbi.sln\` folder to their solution, reference from their app.
-2. Open up your \`MainPage.cs\` app
-  - Add \`using Alice.Bobbi.AliceBobbi;\` to the usings at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the \`List<IReactPackage>\` returned by the \`Packages\` method
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -129,32 +129,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -129,32 +129,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -129,32 +129,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`AliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.reactlibrary.AliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -123,32 +123,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### iOS
-
-1. In XCode, in the project navigator, right click \`Libraries\` ➜ \`Add Files to [your project's name]\`
-2. Go to \`node_modules\` ➜ \`react-native-alice-bobbi\` and add \`ABCAliceBobbi.xcodeproj\`
-3. In XCode, in the project navigator, select your project. Add \`libABCAliceBobbi.a\` to your project's \`Build Phases\` ➜ \`Link Binary With Libraries\`
-4. Run your project (\`Cmd+R\`)<
-
-#### Android
-
-1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
-  - Add \`import com.alicebits.ABCAliceBobbiPackage;\` to the imports at the top of the file
-  - Add \`new ABCAliceBobbiPackage()\` to the list returned by the \`getPackages()\` method
-2. Append the following lines to \`android/settings.gradle\`:
-  	\`\`\`
-  	include ':react-native-alice-bobbi'
-  	project(':react-native-alice-bobbi').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-alice-bobbi/android')
-  	\`\`\`
-3. Insert the following lines inside the dependencies block in \`android/app/build.gradle\`:
-  	\`\`\`
-      compile project(':react-native-alice-bobbi')
-  	\`\`\`
-
-
 ## Usage
 \`\`\`javascript
 import ABCAliceBobbi from 'react-native-alice-bobbi';

--- a/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
@@ -62,18 +62,6 @@ Array [
 
 \`$ react-native link react-native-alice-bobbi\`
 
-### Manual installation
-
-
-#### Windows
-[Read it! :D](https://github.com/ReactWindows/react-native)
-
-1. In Visual Studio add the \`AliceBobbi.sln\` in \`node_modules/react-native-alice-bobbi/windows/AliceBobbi.sln\` folder to their solution, reference from their app.
-2. Open up your \`MainPage.cs\` app
-  - Add \`using Carol.AliceBobbi;\` to the usings at the top of the file
-  - Add \`new AliceBobbiPackage()\` to the \`List<IReactPackage>\` returned by the \`Packages\` method
-
-
 ## Usage
 \`\`\`javascript
 import AliceBobbi from 'react-native-alice-bobbi';


### PR DESCRIPTION
_now generated by an expression function, with some argument properties removed_

since manual installation is not and will not be supported

in response to the discussion of Xcode 11 build issues in #159

~~TODO:~~

- [x] ~~ensure that `yarn lint` succeeds~~
- [x] ~~ensure that `npm test` (or `yarn test`) succeeds~~