### PR TITLE
update stryker.conf.js to include templates

### DIFF
--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,6 +1,7 @@
 module.exports = config => {
   config.set({
     mutator: 'javascript',
+    mutate: ['lib/**/*.js', 'templates/**/*.js'],
     packageManager: 'yarn',
     reporters: ['html', 'clear-text', 'progress'],
     testRunner: 'jest',


### PR DESCRIPTION
Seems to add about 50% to the mutation testing time, should not be an issue on modern systems.

Does not seem to find any more mutants in `templates` at this point.