### PR TITLE
doc fixes for tvOS platform fork (quick fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
 - Platform fork support
   - tvOS platform support
     - requires the [`react-native-tvos`](https://www.npmjs.com/package/react-native-tvos) fork (see discussion in [react-native-community/react-native-tvos#11](https://github.com/react-native-community/react-native-tvos/issues/11))
-    - unstable with very limited testing and no active support from the primary maintainer
+    - unstable with very limited testing, with limited if any active support from the primary maintainer [@brodybits](https://github.com/brodybits)
     - minimum react-native-tvos version is 0.60 (see [issue #95](https://github.com/brodybits/create-react-native-module/issues/95))
 - Out-of-tree platform support
   - Windows - unstable (not tested, see [issue #23](https://github.com/brodybits/create-react-native-module/issues/23)); now deprecated and may be removed in the near future (see [issue #43](https://github.com/brodybits/create-react-native-module/issues/43))

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
 - Platform fork support
   - tvOS platform support
     - requires the [`react-native-tvos`](https://www.npmjs.com/package/react-native-tvos) fork (see discussion in [react-native-community/react-native-tvos#11](https://github.com/react-native-community/react-native-tvos/issues/11))
-    - unstable with very limited testing, with limited if any active support from the primary maintainer [@brodybits](https://github.com/brodybits)
+    - unstable with very limited testing, with limited if any active support from the primary maintainer [@brodybits](https://github.com/brodybits) (see [issue #127](https://github.com/brodybits/create-react-native-module/issues/127))
     - minimum react-native-tvos version is 0.60 (see [issue #95](https://github.com/brodybits/create-react-native-module/issues/95))
 - Out-of-tree platform support
   - Windows - unstable (not tested, see [issue #23](https://github.com/brodybits/create-react-native-module/issues/23)); now deprecated and may be removed in the near future (see [issue #43](https://github.com/brodybits/create-react-native-module/issues/43))

--- a/README.md
+++ b/README.md
@@ -34,8 +34,12 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
   - [issue #99](https://github.com/brodybits/create-react-native-module/issues/99) - additional `pod install` step needed for RN 0.60 on iOS
   - [issue #29](https://github.com/brodybits/create-react-native-module/issues/29) - View does not work with RN 0.60 on Android (quick patch needed)
   - React Native 0.60(+) currently not supported by Expo or react-native-windows
+- Platform fork support
+  - tvOS platform support
+    - requires the [`react-native-tvos`](https://www.npmjs.com/package/react-native-tvos) fork (see discussion in [react-native-community/react-native-tvos#11](https://github.com/react-native-community/react-native-tvos/issues/11))
+    - unstable with very limited testing and no active support from the primary maintainer
+    - minimum react-native-tvos version is 0.60 (see [issue #95](https://github.com/brodybits/create-react-native-module/issues/95))
 - Out-of-tree platform support
-  - tvOS platform support - unstable with very limited testing, minimum react-native-tvos version is 0.60 (see [issue #95](https://github.com/brodybits/create-react-native-module/issues/95))
   - Windows - unstable (not tested, see [issue #23](https://github.com/brodybits/create-react-native-module/issues/23)); now deprecated and may be removed in the near future (see [issue #43](https://github.com/brodybits/create-react-native-module/issues/43))
   - for future consideration: macOS (see [issue #94](https://github.com/brodybits/create-react-native-module/issues/94))
 - Node.js pre-10 support is deprecated and will be removed in the near future (see [issue #38](https://github.com/brodybits/create-react-native-module/issues/38))


### PR DESCRIPTION
Document tvOS as a platform fork and not an "out of tree platform", with all of the points in a special bullet list.

This is to update the documentation of the actual status before merging PR #126 to make tvOS platform support optional.

/cc @dlowder-salesforce