### PR TITLE
[DRAFT WIP TBD ...] Use gulp vinyl-fs

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -4,6 +4,8 @@ const path = require('path');
 
 // External imports:
 
+const gulp = require('gulp');
+
 // default execa object
 const execaDefault = require('execa');
 
@@ -146,8 +148,10 @@ const generateWithNormalizedOptions = ({
 
   console.info('CREATE: Generating the React Native library module');
 
+  const moduleNameTmp = `${moduleName}-tmp`;
+
   const generateLibraryModule = () => {
-    return fs.ensureDir(moduleName).then(() => {
+    return fs.ensureDir(moduleNameTmp).then(() => {
       return Promise.all(templates.filter((template) => {
         if (template.platform) {
           return (platforms.indexOf(template.platform) >= 0);
@@ -157,7 +161,7 @@ const generateWithNormalizedOptions = ({
       }).map((template) => {
         const templateArgs = {
           name: className,
-          moduleName,
+          moduleName: moduleNameTmp,
           packageIdentifier,
           namespace,
           platforms,
@@ -172,8 +176,13 @@ const generateWithNormalizedOptions = ({
           exampleName,
         };
 
-        return renderTemplateIfValid(fs, moduleName, template, templateArgs);
+        return renderTemplateIfValid(fs, moduleNameTmp, template, templateArgs);
       }));
+    }).then(() => {
+      // THANKGS for guidance:
+      // https://stackoverflow.com/questions/25038014/how-do-i-copy-directories-recursively-with-gulp/27433579#27433579
+      gulp.src([`${moduleNameTmp}/.*`, `${moduleNameTmp}/**/*`])
+        .pipe(gulp.dest(moduleName));
     });
   };
 

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -16,6 +16,8 @@ const jsonfile = require('jsonfile');
 
 const pump = require('pump');
 
+const vfs = require('vinyl-fs');
+
 // Internal imports:
 
 const normalizedOptions = require('./normalized-options');
@@ -186,7 +188,7 @@ const generateWithNormalizedOptions = ({
       // * https://django.cowhite.com/blog/using-gulp-to-pipeline-front-end-builds/
       pump(
         gulp.src([`${moduleNameTmp}/.*`, `${moduleNameTmp}/**/*`]),
-        gulp.dest(moduleName)
+        vfs.dest(moduleName)
       );
     });
   };

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -4,9 +4,6 @@ const path = require('path');
 
 // External imports:
 
-// XXX GONE:
-// const gulp = require('gulp');
-
 // default execa object
 const execaDefault = require('execa');
 
@@ -187,6 +184,11 @@ const generateWithNormalizedOptions = ({
       // THANKGS for guidance:
       // * https://stackoverflow.com/questions/25038014/how-do-i-copy-directories-recursively-with-gulp/27433579#27433579
       // * https://django.cowhite.com/blog/using-gulp-to-pipeline-front-end-builds/
+      // vfs TODO items:
+      // - use vfs for generated example artifacts that need to be (over)written
+      // - check output using vinyl-fs-mock
+      // - consider using tmp to generate the artifacts in a directory with *correct* (unmangled) module name
+      // - consider using a utility such as vinyl-fs-mock to get a pump source more cleanly
       pump(
         vfs.src([`${moduleNameTmp}/.*`, `${moduleNameTmp}/**/*`]),
         vfs.dest(moduleName)

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -14,6 +14,8 @@ const fsExtra = require('fs-extra');
 
 const jsonfile = require('jsonfile');
 
+const pump = require('pump');
+
 // Internal imports:
 
 const normalizedOptions = require('./normalized-options');
@@ -180,9 +182,12 @@ const generateWithNormalizedOptions = ({
       }));
     }).then(() => {
       // THANKGS for guidance:
-      // https://stackoverflow.com/questions/25038014/how-do-i-copy-directories-recursively-with-gulp/27433579#27433579
-      gulp.src([`${moduleNameTmp}/.*`, `${moduleNameTmp}/**/*`])
-        .pipe(gulp.dest(moduleName));
+      // * https://stackoverflow.com/questions/25038014/how-do-i-copy-directories-recursively-with-gulp/27433579#27433579
+      // * https://django.cowhite.com/blog/using-gulp-to-pipeline-front-end-builds/
+      pump(
+        gulp.src([`${moduleNameTmp}/.*`, `${moduleNameTmp}/**/*`]),
+        gulp.dest(moduleName)
+      );
     });
   };
 

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -4,7 +4,8 @@ const path = require('path');
 
 // External imports:
 
-const gulp = require('gulp');
+// XXX GONE:
+// const gulp = require('gulp');
 
 // default execa object
 const execaDefault = require('execa');
@@ -187,7 +188,7 @@ const generateWithNormalizedOptions = ({
       // * https://stackoverflow.com/questions/25038014/how-do-i-copy-directories-recursively-with-gulp/27433579#27433579
       // * https://django.cowhite.com/blog/using-gulp-to-pipeline-front-end-builds/
       pump(
-        gulp.src([`${moduleNameTmp}/.*`, `${moduleNameTmp}/**/*`]),
+        vfs.src([`${moduleNameTmp}/.*`, `${moduleNameTmp}/**/*`]),
         vfs.dest(moduleName)
       );
     });

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "pascal-case": "^2.0.1",
     "pump": "^3.0.0",
     "update-notifier": "^3.0.1",
-    "uuid": "^3.3.3"
+    "uuid": "^3.3.3",
+    "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
     "@stryker-mutator/core": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "node-emoji": "^1.10.0",
     "param-case": "^2.1.1",
     "pascal-case": "^2.0.1",
+    "pump": "^3.0.0",
     "update-notifier": "^3.0.1",
     "uuid": "^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "commander": "^3.0.1",
     "execa": "^3.3.0",
     "fs-extra": "^8.1.0",
-    "gulp": "^4.0.2",
     "jsonfile": "^5.0.0",
     "node-emoji": "^1.10.0",
     "param-case": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "commander": "^3.0.1",
     "execa": "^3.3.0",
     "fs-extra": "^8.1.0",
+    "gulp": "^4.0.2",
     "jsonfile": "^5.0.0",
     "node-emoji": "^1.10.0",
     "param-case": "^2.1.1",

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -59,19 +59,19 @@ buck-out/
   },
   Object {
     "name": "react-native-integration-view-test-package/README.md",
-    "theContent": "# react-native-integration-view-test-package
+    "theContent": "# react-native-integration-view-test-package-tmp
 
 ## Getting started
 
-\`$ npm install react-native-integration-view-test-package --save\`
+\`$ npm install react-native-integration-view-test-package-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-integration-view-test-package\`
+\`$ react-native link react-native-integration-view-test-package-tmp\`
 
 ## Usage
 \`\`\`javascript
-import IntegrationViewTestPackage from 'react-native-integration-view-test-package';
+import IntegrationViewTestPackage from 'react-native-integration-view-test-package-tmp';
 
 // TODO: What to do with the module?
 IntegrationViewTestPackage;
@@ -645,8 +645,8 @@ RCT_EXPORT_MODULE()
   Object {
     "name": "react-native-integration-view-test-package/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-integration-view-test-package\\",
-  \\"title\\": \\"React Native Integration View Test Package\\",
+  \\"name\\": \\"react-native-integration-view-test-package-tmp\\",
+  \\"title\\": \\"React Native Integration View Test Package Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -655,8 +655,8 @@ RCT_EXPORT_MODULE()
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-integration-view-test-package.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-integration-view-test-package\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-integration-view-test-package-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-integration-view-test-package-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -680,24 +680,24 @@ RCT_EXPORT_MODULE()
 ",
   },
   Object {
-    "name": "react-native-integration-view-test-package/react-native-integration-view-test-package.podspec",
+    "name": "react-native-integration-view-test-package/react-native-integration-view-test-package-tmp.podspec",
     "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-integration-view-test-package\\"
+  s.name         = \\"react-native-integration-view-test-package-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-integration-view-test-package
+                  react-native-integration-view-test-package-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-integration-view-test-package\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-integration-view-test-package-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-integration-view-test-package.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-integration-view-test-package-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -59,19 +59,19 @@ buck-out/
   },
   Object {
     "name": "react-native-integration-test-package/README.md",
-    "theContent": "# react-native-integration-test-package
+    "theContent": "# react-native-integration-test-package-tmp
 
 ## Getting started
 
-\`$ npm install react-native-integration-test-package --save\`
+\`$ npm install react-native-integration-test-package-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-integration-test-package\`
+\`$ react-native link react-native-integration-test-package-tmp\`
 
 ## Usage
 \`\`\`javascript
-import IntegrationTestPackage from 'react-native-integration-test-package';
+import IntegrationTestPackage from 'react-native-integration-test-package-tmp';
 
 // TODO: What to do with the module?
 IntegrationTestPackage;
@@ -638,8 +638,8 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   Object {
     "name": "react-native-integration-test-package/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-integration-test-package\\",
-  \\"title\\": \\"React Native Integration Test Package\\",
+  \\"name\\": \\"react-native-integration-test-package-tmp\\",
+  \\"title\\": \\"React Native Integration Test Package Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -648,8 +648,8 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-integration-test-package.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-integration-test-package\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-integration-test-package-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-integration-test-package-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -673,24 +673,24 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "name": "react-native-integration-test-package/react-native-integration-test-package.podspec",
+    "name": "react-native-integration-test-package/react-native-integration-test-package-tmp.podspec",
     "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-integration-test-package\\"
+  s.name         = \\"react-native-integration-test-package-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-integration-test-package
+                  react-native-integration-test-package-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-integration-test-package\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-integration-test-package-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-integration-test-package.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-integration-test-package-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -2,56 +2,56 @@
 
 exports[`create alice-bobbi view module with defaults 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -59,12 +59,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -73,8 +73,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -98,7 +98,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { requireNativeComponent } from 'react-native';
@@ -109,7 +109,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -157,20 +157,20 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -323,7 +323,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -333,7 +333,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiManager.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiManager.java
 content:
 --------
 package com.reactlibrary;
@@ -368,7 +368,7 @@ public class AliceBobbiManager extends SimpleViewManager<View> {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -397,7 +397,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -417,7 +417,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -425,18 +425,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -449,7 +449,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTViewManager.h>
@@ -460,7 +460,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -485,7 +485,7 @@ RCT_EXPORT_MODULE()
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -498,7 +498,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -6,56 +6,56 @@ Array [
 ",
   "* execa.commandSync command: yarn --version options: {\\"stdio\\":\\"inherit\\"}
 ",
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -63,12 +63,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -77,8 +77,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -102,7 +102,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { requireNativeComponent } from 'react-native';
@@ -113,7 +113,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -161,21 +161,21 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 example
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -328,7 +328,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -338,7 +338,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiManager.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiManager.java
 content:
 --------
 package com.reactlibrary;
@@ -373,7 +373,7 @@ public class AliceBobbiManager extends SimpleViewManager<View> {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -402,7 +402,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -422,7 +422,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -430,18 +430,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -454,7 +454,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTViewManager.h>
@@ -465,7 +465,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -490,7 +490,7 @@ RCT_EXPORT_MODULE()
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -503,7 +503,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -6,56 +6,56 @@ Array [
 ",
   "* execa.commandSync command: yarn --version options: {\\"stdio\\":\\"inherit\\"}
 ",
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -63,12 +63,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -77,8 +77,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -102,7 +102,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { requireNativeComponent } from 'react-native';
@@ -113,7 +113,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -161,21 +161,21 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 test-demo
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -328,7 +328,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -338,7 +338,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiManager.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiManager.java
 content:
 --------
 package com.reactlibrary;
@@ -373,7 +373,7 @@ public class AliceBobbiManager extends SimpleViewManager<View> {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -402,7 +402,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -422,7 +422,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -430,18 +430,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Alice\\" => \\"contact@alice.me\\" }
   s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
-  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -454,7 +454,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTViewManager.h>
@@ -465,7 +465,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -490,7 +490,7 @@ RCT_EXPORT_MODULE()
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -503,7 +503,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -2,46 +2,46 @@
 
 exports[`create alice-bobbi view module with config options for Android only 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -49,12 +49,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -63,8 +63,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -88,7 +88,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { requireNativeComponent } from 'react-native';
@@ -99,7 +99,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -127,19 +127,19 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -292,7 +292,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -302,7 +302,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiManager.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiManager.java
 content:
 --------
 package com.reactlibrary;
@@ -337,7 +337,7 @@ public class AliceBobbiManager extends SimpleViewManager<View> {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -366,7 +366,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README

--- a/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
@@ -2,46 +2,46 @@
 
 exports[`create alice-bobbi view module with config options for iOS only 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -49,12 +49,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -63,8 +63,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -88,7 +88,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { requireNativeComponent } from 'react-native';
@@ -99,7 +99,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -134,20 +134,20 @@ project.xcworkspace
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -155,18 +155,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Alice\\" => \\"contact@alice.me\\" }
   s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
-  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -179,7 +179,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTViewManager.h>
@@ -190,7 +190,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -215,7 +215,7 @@ RCT_EXPORT_MODULE()
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -228,7 +228,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -2,56 +2,56 @@
 
 exports[`create alice-bobbi module with defaults 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -59,12 +59,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -73,8 +73,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -98,7 +98,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -109,7 +109,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -157,20 +157,20 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -323,7 +323,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -333,7 +333,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -366,7 +366,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -395,7 +395,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -415,7 +415,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -423,18 +423,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -447,7 +447,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -458,7 +458,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -478,7 +478,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -491,7 +491,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
@@ -2,36 +2,36 @@
 
 exports[`create alice-bobbi module with defaults, with platforms: 'bogus' 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -39,12 +39,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -53,8 +53,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -78,7 +78,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -89,7 +89,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -104,13 +104,13 @@ yarn-error.log
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
@@ -2,36 +2,36 @@
 
 exports[`create alice-bobbi module with defaults, with bogus platforms: [] 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -39,12 +39,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -53,8 +53,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -78,7 +78,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -89,7 +89,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -104,13 +104,13 @@ yarn-error.log
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
@@ -2,36 +2,36 @@
 
 exports[`create alice-bobbi module with defaults, with bogus platforms: '' 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -39,12 +39,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -53,8 +53,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -78,7 +78,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -89,7 +89,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -104,13 +104,13 @@ yarn-error.log
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -6,56 +6,56 @@ Array [
 ",
   "* execa.commandSync command: yarn --version options: {\\"stdio\\":\\"inherit\\"}
 ",
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -63,12 +63,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -77,8 +77,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -102,7 +102,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -113,7 +113,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -161,21 +161,21 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 example
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -328,7 +328,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -338,7 +338,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -371,7 +371,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -400,7 +400,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -420,7 +420,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -428,18 +428,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -452,7 +452,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -463,7 +463,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -483,7 +483,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -496,7 +496,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -6,56 +6,56 @@ Array [
 ",
   "* execa.commandSync command: yarn --version options: {\\"stdio\\":\\"inherit\\"}
 ",
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -63,12 +63,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -77,8 +77,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -102,7 +102,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -113,7 +113,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -161,21 +161,21 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 example
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -328,7 +328,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -338,7 +338,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -371,7 +371,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -400,7 +400,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -420,7 +420,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -428,18 +428,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -452,7 +452,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -463,7 +463,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -483,7 +483,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -496,7 +496,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -6,56 +6,56 @@ Array [
 ",
   "* execa.commandSync command: yarn --version options: {\\"stdio\\":\\"inherit\\"}
 ",
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -63,12 +63,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -77,8 +77,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -102,7 +102,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -113,7 +113,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -161,21 +161,21 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 example
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -328,7 +328,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -338,7 +338,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -371,7 +371,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -400,7 +400,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -420,7 +420,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -428,18 +428,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -452,7 +452,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -463,7 +463,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -483,7 +483,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -496,7 +496,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -6,56 +6,56 @@ Array [
 ",
   "* execa.commandSync command: yarn --version options: {\\"stdio\\":\\"inherit\\"}
 ",
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -63,12 +63,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -77,8 +77,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -102,7 +102,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -113,7 +113,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -161,21 +161,21 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 test-demo
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -328,7 +328,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -338,7 +338,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -371,7 +371,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -400,7 +400,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -420,7 +420,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -428,18 +428,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Alice\\" => \\"contact@alice.me\\" }
   s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
-  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -452,7 +452,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -463,7 +463,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -489,7 +489,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -502,7 +502,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -2,56 +2,56 @@
 
 exports[`create alice-bobbi module with name in camel case 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -59,12 +59,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -73,8 +73,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -98,7 +98,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -109,7 +109,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -157,20 +157,20 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -323,7 +323,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -333,7 +333,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -366,7 +366,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -395,7 +395,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -415,7 +415,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -423,18 +423,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -447,7 +447,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -458,7 +458,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -478,7 +478,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -491,7 +491,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -2,46 +2,46 @@
 
 exports[`create alice-bobbi module with config options for Android only 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/alicebits/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/alicebits/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/alicebits/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/alicebits/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -49,12 +49,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -63,8 +63,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -88,7 +88,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -99,7 +99,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -127,19 +127,19 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -292,7 +292,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -302,7 +302,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/alicebits/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/alicebits/AliceBobbiModule.java
 content:
 --------
 package com.alicebits;
@@ -335,7 +335,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/alicebits/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/alicebits/AliceBobbiPackage.java
 content:
 --------
 package com.alicebits;
@@ -364,7 +364,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -2,46 +2,46 @@
 
 exports[`create alice-bobbi module with config options for iOS only 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -49,12 +49,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -63,8 +63,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -88,7 +88,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -99,7 +99,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -134,20 +134,20 @@ project.xcworkspace
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -155,18 +155,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Alice\\" => \\"contact@alice.me\\" }
   s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
-  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -179,7 +179,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -190,7 +190,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -216,7 +216,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -229,7 +229,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -2,56 +2,56 @@
 
 exports[`create alice-bobbi module with config options for android,ios comma separated 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/ABCAliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/ABCAliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import ABCAliceBobbi from 'react-native-alice-bobbi';
+import ABCAliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 ABCAliceBobbi;
@@ -59,12 +59,12 @@ ABCAliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -73,8 +73,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -98,7 +98,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -109,7 +109,7 @@ export default ABCAliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -157,20 +157,20 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -323,7 +323,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -333,7 +333,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/ABCAliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/ABCAliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -366,7 +366,7 @@ public class ABCAliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/ABCAliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/ABCAliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -395,7 +395,7 @@ public class ABCAliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -415,7 +415,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -423,18 +423,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Alice\\" => \\"contact@alice.me\\" }
   s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
-  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -447,7 +447,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/ABCAliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -458,7 +458,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/ABCAliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.m
 content:
 --------
 #import \\"ABCAliceBobbi.h\\"
@@ -478,7 +478,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/ABCAliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -491,7 +491,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/ABCAliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -2,56 +2,56 @@
 
 exports[`create alice-bobbi module with config options for android,ios comma separated 1`] = `
 Array [
-  "* ensureDir dir: react-native-alice-bobbi
+  "* ensureDir dir: react-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/android/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: react-native-alice-bobbi/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/README.md
 content:
 --------
-# react-native-alice-bobbi
+# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -59,12 +59,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/package.json
+  "* outputFile name: react-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -73,8 +73,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -98,7 +98,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/index.js
+  "* outputFile name: react-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -109,7 +109,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -157,20 +157,20 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
+  "* outputFile name: react-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/.npmignore
+  "* outputFile name: react-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+  "* outputFile name: react-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -323,7 +323,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -333,7 +333,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -366,7 +366,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -395,7 +395,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/README.md
+  "* outputFile name: react-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -415,7 +415,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/react-native-alice-bobbi.podspec
+  "* outputFile name: react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -423,18 +423,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Alice\\" => \\"contact@alice.me\\" }
   s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
-  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -447,7 +447,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -458,7 +458,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -478,7 +478,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -491,7 +491,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -2,56 +2,56 @@
 
 exports[`create alice-bobbi module with modulePrefix: 'custom-native' 1`] = `
 Array [
-  "* ensureDir dir: custom-native-alice-bobbi
+  "* ensureDir dir: custom-native-alice-bobbi-tmp
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/android/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/android/src/main/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/android/src/main/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/android/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/android/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/ios/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/ios/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/ios/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: custom-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: custom-native-alice-bobbi/README.md
+  "* outputFile name: custom-native-alice-bobbi-tmp/README.md
 content:
 --------
-# custom-native-alice-bobbi
+# custom-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install custom-native-alice-bobbi --save\`
+\`$ npm install custom-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link custom-native-alice-bobbi\`
+\`$ react-native link custom-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'custom-native-alice-bobbi';
+import AliceBobbi from 'custom-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -59,12 +59,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/package.json
+  "* outputFile name: custom-native-alice-bobbi-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"custom-native-alice-bobbi\\",
-  \\"title\\": \\"Custom Native Alice Bobbi\\",
+  \\"name\\": \\"custom-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"Custom Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -73,8 +73,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/custom-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/custom-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/custom-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/custom-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -98,7 +98,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/index.js
+  "* outputFile name: custom-native-alice-bobbi-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -109,7 +109,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/.gitignore
+  "* outputFile name: custom-native-alice-bobbi-tmp/.gitignore
 content:
 --------
 # OSX
@@ -157,20 +157,20 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/.gitattributes
+  "* outputFile name: custom-native-alice-bobbi-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/.npmignore
+  "* outputFile name: custom-native-alice-bobbi-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/android/build.gradle
+  "* outputFile name: custom-native-alice-bobbi-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -323,7 +323,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/android/src/main/AndroidManifest.xml
+  "* outputFile name: custom-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -333,7 +333,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: custom-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -366,7 +366,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: custom-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -395,7 +395,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/android/README.md
+  "* outputFile name: custom-native-alice-bobbi-tmp/android/README.md
 content:
 --------
 README
@@ -415,7 +415,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/custom-native-alice-bobbi.podspec
+  "* outputFile name: custom-native-alice-bobbi-tmp/custom-native-alice-bobbi-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -423,18 +423,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"custom-native-alice-bobbi\\"
+  s.name         = \\"custom-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  custom-native-alice-bobbi
+                  custom-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/custom-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/custom-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/custom-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/custom-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -447,7 +447,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: custom-native-alice-bobbi-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -458,7 +458,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: custom-native-alice-bobbi-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -478,7 +478,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: custom-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -491,7 +491,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: custom-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -2,56 +2,56 @@
 
 exports[`create alice-bobbi module with moduleName: 'custom-native-module' 1`] = `
 Array [
-  "* ensureDir dir: custom-native-module
+  "* ensureDir dir: custom-native-module-tmp
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-tmp/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-tmp/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-tmp/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-tmp/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-tmp/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-tmp/
 ",
-  "* ensureDir dir: custom-native-module/android/
+  "* ensureDir dir: custom-native-module-tmp/android/
 ",
-  "* ensureDir dir: custom-native-module/android/src/main/
+  "* ensureDir dir: custom-native-module-tmp/android/src/main/
 ",
-  "* ensureDir dir: custom-native-module/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: custom-native-module-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: custom-native-module/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: custom-native-module-tmp/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: custom-native-module/android/
+  "* ensureDir dir: custom-native-module-tmp/android/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-tmp/
 ",
-  "* ensureDir dir: custom-native-module/ios/
+  "* ensureDir dir: custom-native-module-tmp/ios/
 ",
-  "* ensureDir dir: custom-native-module/ios/
+  "* ensureDir dir: custom-native-module-tmp/ios/
 ",
-  "* ensureDir dir: custom-native-module/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: custom-native-module-tmp/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: custom-native-module/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: custom-native-module-tmp/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: custom-native-module/README.md
+  "* outputFile name: custom-native-module-tmp/README.md
 content:
 --------
-# custom-native-module
+# custom-native-module-tmp
 
 ## Getting started
 
-\`$ npm install custom-native-module --save\`
+\`$ npm install custom-native-module-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link custom-native-module\`
+\`$ react-native link custom-native-module-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'custom-native-module';
+import AliceBobbi from 'custom-native-module-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -59,12 +59,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/package.json
+  "* outputFile name: custom-native-module-tmp/package.json
 content:
 --------
 {
-  \\"name\\": \\"custom-native-module\\",
-  \\"title\\": \\"Custom Native Module\\",
+  \\"name\\": \\"custom-native-module-tmp\\",
+  \\"title\\": \\"Custom Native Module Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -73,8 +73,8 @@ content:
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/custom-native-module.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/custom-native-module\\"
+    \\"url\\": \\"git+https://github.com/github_account/custom-native-module-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/custom-native-module-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -98,7 +98,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/index.js
+  "* outputFile name: custom-native-module-tmp/index.js
 content:
 --------
 import { NativeModules } from 'react-native';
@@ -109,7 +109,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/.gitignore
+  "* outputFile name: custom-native-module-tmp/.gitignore
 content:
 --------
 # OSX
@@ -157,20 +157,20 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/.gitattributes
+  "* outputFile name: custom-native-module-tmp/.gitattributes
 content:
 --------
 *.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/.npmignore
+  "* outputFile name: custom-native-module-tmp/.npmignore
 content:
 --------
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/build.gradle
+  "* outputFile name: custom-native-module-tmp/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -323,7 +323,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/src/main/AndroidManifest.xml
+  "* outputFile name: custom-native-module-tmp/android/src/main/AndroidManifest.xml
 content:
 --------
 <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
@@ -333,7 +333,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: custom-native-module-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 package com.reactlibrary;
@@ -366,7 +366,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: custom-native-module-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 package com.reactlibrary;
@@ -395,7 +395,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/README.md
+  "* outputFile name: custom-native-module-tmp/android/README.md
 content:
 --------
 README
@@ -415,7 +415,7 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/custom-native-module.podspec
+  "* outputFile name: custom-native-module-tmp/custom-native-module-tmp.podspec
 content:
 --------
 require \\"json\\"
@@ -423,18 +423,18 @@ require \\"json\\"
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"custom-native-module\\"
+  s.name         = \\"custom-native-module-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  custom-native-module
+                  custom-native-module-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/custom-native-module\\"
+  s.homepage     = \\"https://github.com/github_account/custom-native-module-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/custom-native-module.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/custom-native-module-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -447,7 +447,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/ios/AliceBobbi.h
+  "* outputFile name: custom-native-module-tmp/ios/AliceBobbi.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
@@ -458,7 +458,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/ios/AliceBobbi.m
+  "* outputFile name: custom-native-module-tmp/ios/AliceBobbi.m
 content:
 --------
 #import \\"AliceBobbi.h\\"
@@ -478,7 +478,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: custom-native-module-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -491,7 +491,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: custom-native-module-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -37,41 +37,41 @@ Array [
     ],
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -79,10 +79,10 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -91,8 +91,8 @@ AliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -116,7 +116,7 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { AliceBobbi } = NativeModules;
@@ -125,7 +125,7 @@ export default AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -138,11 +138,11 @@ yarn-error.log
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "",
   },
   Object {

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -37,41 +37,41 @@ Array [
     ],
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -79,10 +79,10 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -91,8 +91,8 @@ AliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -116,7 +116,7 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { AliceBobbi } = NativeModules;
@@ -125,7 +125,7 @@ export default AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -138,11 +138,11 @@ yarn-error.log
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "",
   },
   Object {

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -37,7 +37,7 @@ Array [
     ],
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
     "error": Array [
@@ -48,9 +48,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:150:15)
-    at generateLibraryModule (.../lib/lib.js:245:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:262:10)
+    at ensureDir (.../lib/lib.js:154:15)
+    at generateLibraryModule (.../lib/lib.js:254:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:271:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -48,9 +48,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:154:15)
-    at generateLibraryModule (.../lib/lib.js:254:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:271:10)
+    at ensureDir (.../lib/lib.js:156:15)
+    at generateLibraryModule (.../lib/lib.js:259:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:276:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -48,9 +48,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:156:15)
-    at generateLibraryModule (.../lib/lib.js:259:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:276:10)
+    at ensureDir (.../lib/lib.js:159:15)
+    at generateLibraryModule (.../lib/lib.js:262:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:279:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -48,9 +48,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:159:15)
-    at generateLibraryModule (.../lib/lib.js:262:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:279:10)
+    at ensureDir (.../lib/lib.js:156:15)
+    at generateLibraryModule (.../lib/lib.js:264:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:281:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -3,71 +3,71 @@
 exports[`create alice-bobbi module with explicit config options for Android & iOS 1`] = `
 Array [
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -75,10 +75,10 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -87,8 +87,8 @@ AliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -112,7 +112,7 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { AliceBobbi } = NativeModules;
@@ -121,7 +121,7 @@ export default AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -167,16 +167,16 @@ buck-out/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "*.pbxproj -text
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/build.gradle",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/build.gradle",
     "theContent": "// android/build.gradle
 
 // based on:
@@ -327,7 +327,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/AndroidManifest.xml",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml",
     "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
           package=\\"com.reactlibrary\\">
 
@@ -335,7 +335,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
     "theContent": "package com.reactlibrary;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -366,7 +366,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
     "theContent": "package com.reactlibrary;
 
 import java.util.Arrays;
@@ -393,7 +393,7 @@ public class AliceBobbiPackage implements ReactPackage {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/README.md",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/README.md",
     "theContent": "README
 ======
 
@@ -411,24 +411,24 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/react-native-alice-bobbi.podspec",
+    "outputFileName": "react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec",
     "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Alice\\" => \\"contact@alice.me\\" }
   s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
-  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -441,7 +441,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.h",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.h",
     "theContent": "#import <React/RCTBridgeModule.h>
 
 @interface AliceBobbi : NSObject <RCTBridgeModule>
@@ -450,7 +450,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.m",
     "theContent": "#import \\"AliceBobbi.h\\"
 
 
@@ -468,7 +468,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <Workspace
    version = \\"1.0\\">
@@ -479,7 +479,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj",
     "theContent": "// !$*UTF8*$!
 {
 	archiveVersion = 1;

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -189,56 +189,56 @@ Array [
     },
   },
   Object {
-    "ensureDir": "react-native-test-package",
+    "ensureDir": "react-native-test-package-tmp",
   },
   Object {
-    "ensureDir": "react-native-test-package/",
+    "ensureDir": "react-native-test-package-tmp/",
   },
   Object {
-    "ensureDir": "react-native-test-package/",
+    "ensureDir": "react-native-test-package-tmp/",
   },
   Object {
-    "ensureDir": "react-native-test-package/",
+    "ensureDir": "react-native-test-package-tmp/",
   },
   Object {
-    "ensureDir": "react-native-test-package/",
+    "ensureDir": "react-native-test-package-tmp/",
   },
   Object {
-    "ensureDir": "react-native-test-package/",
+    "ensureDir": "react-native-test-package-tmp/",
   },
   Object {
-    "ensureDir": "react-native-test-package/",
+    "ensureDir": "react-native-test-package-tmp/",
   },
   Object {
-    "ensureDir": "react-native-test-package/android/",
+    "ensureDir": "react-native-test-package-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-test-package/android/src/main/",
+    "ensureDir": "react-native-test-package-tmp/android/src/main/",
   },
   Object {
-    "ensureDir": "react-native-test-package/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-test-package-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-test-package/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-test-package-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-test-package/android/",
+    "ensureDir": "react-native-test-package-tmp/android/",
   },
   Object {
-    "outputFileName": "react-native-test-package/README.md",
-    "theContent": "# react-native-test-package
+    "outputFileName": "react-native-test-package-tmp/README.md",
+    "theContent": "# react-native-test-package-tmp
 
 ## Getting started
 
-\`$ npm install react-native-test-package --save\`
+\`$ npm install react-native-test-package-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-test-package\`
+\`$ react-native link react-native-test-package-tmp\`
 
 ## Usage
 \`\`\`javascript
-import TestPackage from 'react-native-test-package';
+import TestPackage from 'react-native-test-package-tmp';
 
 // TODO: What to do with the module?
 TestPackage;
@@ -246,10 +246,10 @@ TestPackage;
 ",
   },
   Object {
-    "outputFileName": "react-native-test-package/package.json",
+    "outputFileName": "react-native-test-package-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-test-package\\",
-  \\"title\\": \\"React Native Test Package\\",
+  \\"name\\": \\"react-native-test-package-tmp\\",
+  \\"title\\": \\"React Native Test Package Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -258,8 +258,8 @@ TestPackage;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-test-package.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-test-package\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-test-package-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-test-package-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -283,7 +283,7 @@ TestPackage;
 ",
   },
   Object {
-    "outputFileName": "react-native-test-package/index.js",
+    "outputFileName": "react-native-test-package-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { TestPackage } = NativeModules;
@@ -292,7 +292,7 @@ export default TestPackage;
 ",
   },
   Object {
-    "outputFileName": "react-native-test-package/.gitignore",
+    "outputFileName": "react-native-test-package-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -318,15 +318,15 @@ buck-out/
 ",
   },
   Object {
-    "outputFileName": "react-native-test-package/.gitattributes",
+    "outputFileName": "react-native-test-package-tmp/.gitattributes",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-test-package/.npmignore",
+    "outputFileName": "react-native-test-package-tmp/.npmignore",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-test-package/android/build.gradle",
+    "outputFileName": "react-native-test-package-tmp/android/build.gradle",
     "theContent": "// android/build.gradle
 
 // based on:
@@ -477,7 +477,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-test-package/android/src/main/AndroidManifest.xml",
+    "outputFileName": "react-native-test-package-tmp/android/src/main/AndroidManifest.xml",
     "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
           package=\\"com.reactlibrary\\">
 
@@ -485,7 +485,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-test-package/android/src/main/java/com/reactlibrary/TestPackageModule.java",
+    "outputFileName": "react-native-test-package-tmp/android/src/main/java/com/reactlibrary/TestPackageModule.java",
     "theContent": "package com.reactlibrary;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -516,7 +516,7 @@ public class TestPackageModule extends ReactContextBaseJavaModule {
 ",
   },
   Object {
-    "outputFileName": "react-native-test-package/android/src/main/java/com/reactlibrary/TestPackagePackage.java",
+    "outputFileName": "react-native-test-package-tmp/android/src/main/java/com/reactlibrary/TestPackagePackage.java",
     "theContent": "package com.reactlibrary;
 
 import java.util.Arrays;
@@ -543,7 +543,7 @@ public class TestPackagePackage implements ReactPackage {
 ",
   },
   Object {
-    "outputFileName": "react-native-test-package/android/README.md",
+    "outputFileName": "react-native-test-package-tmp/android/README.md",
     "theContent": "README
 ======
 

--- a/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
@@ -3,68 +3,68 @@
 exports[`create alice-bobbi module using mocked lib with defaults on Windows 1`] = `
 Array [
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/Properties/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/Properties/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/Properties/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/Properties/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -72,10 +72,10 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -84,8 +84,8 @@ AliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -111,7 +111,7 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { AliceBobbi } = NativeModules;
@@ -120,7 +120,7 @@ export default AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -133,15 +133,15 @@ yarn-error.log
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi.sln",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi.sln",
     "theContent": "Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25123.0
@@ -233,7 +233,7 @@ EndGlobal
   ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/.gitignore",
     "theContent": "*AppPackages*
 *BundleArtifacts*
 *ReactAssets*
@@ -315,7 +315,7 @@ packages/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/.npmignore",
     "theContent": "
 # Make sure we don't publish build artifacts to NPM
 ARM/
@@ -328,7 +328,7 @@ obj/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/project.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/project.json",
     "theContent": "{
   \\"dependencies\\": {
     \\"Microsoft.NETCore.UniversalWindowsPlatform\\": \\"5.2.2\\"
@@ -348,7 +348,7 @@ obj/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/AliceBobbi.csproj",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/AliceBobbi.csproj",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <Project ToolsVersion=\\"14.0\\" DefaultTargets=\\"Build\\" xmlns=\\"http://schemas.microsoft.com/developer/msbuild/2003\\">
   <Import Project=\\"$(MSBuildExtensionsPath)\\\\$(MSBuildToolsVersion)\\\\Microsoft.Common.props\\" Condition=\\"Exists('$(MSBuildExtensionsPath)\\\\$(MSBuildToolsVersion)\\\\Microsoft.Common.props')\\" />
@@ -505,7 +505,7 @@ obj/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/AliceBobbiModule.cs",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/AliceBobbiModule.cs",
     "theContent": "using ReactNative.Bridge;
 using System;
 using System.Collections.Generic;
@@ -542,7 +542,7 @@ namespace Alice.Bobbi.AliceBobbi
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/AliceBobbiPackage.cs",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/AliceBobbiPackage.cs",
     "theContent": "using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using ReactNative.UIManager;
@@ -599,7 +599,7 @@ namespace Alice.Bobbi.AliceBobbi
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/Properties/AliceBobbi.rd.xml",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/Properties/AliceBobbi.rd.xml",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <!--
     This file contains Runtime Directives, specifications about types your application accesses
@@ -631,7 +631,7 @@ namespace Alice.Bobbi.AliceBobbi
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/Properties/AssemblyInfo.cs",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/Properties/AssemblyInfo.cs",
     "theContent": "using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -69,71 +69,71 @@ Array [
     ],
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -141,10 +141,10 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -153,8 +153,8 @@ AliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -178,7 +178,7 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { AliceBobbi } = NativeModules;
@@ -187,7 +187,7 @@ export default AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -233,17 +233,17 @@ buck-out/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "*.pbxproj -text
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "example
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/build.gradle",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/build.gradle",
     "theContent": "// android/build.gradle
 
 // based on:
@@ -394,7 +394,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/AndroidManifest.xml",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml",
     "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
           package=\\"com.reactlibrary\\">
 
@@ -402,7 +402,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
     "theContent": "package com.reactlibrary;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -433,7 +433,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
     "theContent": "package com.reactlibrary;
 
 import java.util.Arrays;
@@ -460,7 +460,7 @@ public class AliceBobbiPackage implements ReactPackage {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/README.md",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/README.md",
     "theContent": "README
 ======
 
@@ -478,24 +478,24 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/react-native-alice-bobbi.podspec",
+    "outputFileName": "react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec",
     "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -508,7 +508,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.h",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.h",
     "theContent": "#import <React/RCTBridgeModule.h>
 
 @interface AliceBobbi : NSObject <RCTBridgeModule>
@@ -517,7 +517,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.m",
     "theContent": "#import \\"AliceBobbi.h\\"
 
 
@@ -535,7 +535,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <Workspace
    version = \\"1.0\\">
@@ -546,7 +546,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj",
     "theContent": "// !$*UTF8*$!
 {
 	archiveVersion = 1;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -69,71 +69,71 @@ Array [
     ],
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -141,10 +141,10 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -153,8 +153,8 @@ AliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -178,7 +178,7 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { AliceBobbi } = NativeModules;
@@ -187,7 +187,7 @@ export default AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -233,17 +233,17 @@ buck-out/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "*.pbxproj -text
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "example
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/build.gradle",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/build.gradle",
     "theContent": "// android/build.gradle
 
 // based on:
@@ -394,7 +394,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/AndroidManifest.xml",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml",
     "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
           package=\\"com.reactlibrary\\">
 
@@ -402,7 +402,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
     "theContent": "package com.reactlibrary;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -433,7 +433,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
     "theContent": "package com.reactlibrary;
 
 import java.util.Arrays;
@@ -460,7 +460,7 @@ public class AliceBobbiPackage implements ReactPackage {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/README.md",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/README.md",
     "theContent": "README
 ======
 
@@ -478,24 +478,24 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/react-native-alice-bobbi.podspec",
+    "outputFileName": "react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec",
     "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -508,7 +508,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.h",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.h",
     "theContent": "#import <React/RCTBridgeModule.h>
 
 @interface AliceBobbi : NSObject <RCTBridgeModule>
@@ -517,7 +517,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.m",
     "theContent": "#import \\"AliceBobbi.h\\"
 
 
@@ -535,7 +535,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <Workspace
    version = \\"1.0\\">
@@ -546,7 +546,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj",
     "theContent": "// !$*UTF8*$!
 {
 	archiveVersion = 1;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -69,71 +69,71 @@ Array [
     ],
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -141,10 +141,10 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -153,8 +153,8 @@ AliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -178,7 +178,7 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { AliceBobbi } = NativeModules;
@@ -187,7 +187,7 @@ export default AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -233,17 +233,17 @@ buck-out/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "*.pbxproj -text
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "example
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/build.gradle",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/build.gradle",
     "theContent": "// android/build.gradle
 
 // based on:
@@ -394,7 +394,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/AndroidManifest.xml",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml",
     "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
           package=\\"com.reactlibrary\\">
 
@@ -402,7 +402,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiModule.java",
     "theContent": "package com.reactlibrary;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -433,7 +433,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java",
     "theContent": "package com.reactlibrary;
 
 import java.util.Arrays;
@@ -460,7 +460,7 @@ public class AliceBobbiPackage implements ReactPackage {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/README.md",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/README.md",
     "theContent": "README
 ======
 
@@ -478,24 +478,24 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/react-native-alice-bobbi.podspec",
+    "outputFileName": "react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec",
     "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/github_account/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -508,7 +508,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.h",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.h",
     "theContent": "#import <React/RCTBridgeModule.h>
 
 @interface AliceBobbi : NSObject <RCTBridgeModule>
@@ -517,7 +517,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.m",
     "theContent": "#import \\"AliceBobbi.h\\"
 
 
@@ -535,7 +535,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <Workspace
    version = \\"1.0\\">
@@ -546,7 +546,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/AliceBobbi.xcodeproj/project.pbxproj",
     "theContent": "// !$*UTF8*$!
 {
 	archiveVersion = 1;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -63,71 +63,71 @@ Array [
     ],
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/alicebits/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/alicebits/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/src/main/java/com/alicebits/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/src/main/java/com/alicebits/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/android/",
+    "ensureDir": "react-native-alice-bobbi-tmp/android/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/ABCAliceBobbi.xcworkspace/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.xcworkspace/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/ios/ABCAliceBobbi.xcodeproj/",
+    "ensureDir": "react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.xcodeproj/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import ABCAliceBobbi from 'react-native-alice-bobbi';
+import ABCAliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 ABCAliceBobbi;
@@ -135,10 +135,10 @@ ABCAliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -147,8 +147,8 @@ ABCAliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -172,7 +172,7 @@ ABCAliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { ABCAliceBobbi } = NativeModules;
@@ -181,7 +181,7 @@ export default ABCAliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -227,17 +227,17 @@ buck-out/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "*.pbxproj -text
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "example
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/build.gradle",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/build.gradle",
     "theContent": "// android/build.gradle
 
 // based on:
@@ -388,7 +388,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/AndroidManifest.xml",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/AndroidManifest.xml",
     "theContent": "<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
           package=\\"com.alicebits\\">
 
@@ -396,7 +396,7 @@ afterEvaluate { project ->
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/alicebits/ABCAliceBobbiModule.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/alicebits/ABCAliceBobbiModule.java",
     "theContent": "package com.alicebits;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -427,7 +427,7 @@ public class ABCAliceBobbiModule extends ReactContextBaseJavaModule {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/src/main/java/com/alicebits/ABCAliceBobbiPackage.java",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/src/main/java/com/alicebits/ABCAliceBobbiPackage.java",
     "theContent": "package com.alicebits;
 
 import java.util.Arrays;
@@ -454,7 +454,7 @@ public class ABCAliceBobbiPackage implements ReactPackage {
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/android/README.md",
+    "outputFileName": "react-native-alice-bobbi-tmp/android/README.md",
     "theContent": "README
 ======
 
@@ -472,24 +472,24 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/react-native-alice-bobbi.podspec",
+    "outputFileName": "react-native-alice-bobbi-tmp/react-native-alice-bobbi-tmp.podspec",
     "theContent": "require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"react-native-alice-bobbi\\"
+  s.name         = \\"react-native-alice-bobbi-tmp\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  react-native-alice-bobbi
+                  react-native-alice-bobbi-tmp
                    DESC
-  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+  s.homepage     = \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   s.license      = \\"MIT\\"
   # s.license    = { :type => \\"MIT\\", :file => \\"FILE_LICENSE\\" }
   s.authors      = { \\"Alice\\" => \\"contact@alice.me\\" }
   s.platforms    = { :ios => \\"9.0\\", :tvos => \\"10.0\\" }
-  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,m,swift}\\"
   s.requires_arc = true
@@ -502,7 +502,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/ABCAliceBobbi.h",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.h",
     "theContent": "#import <React/RCTBridgeModule.h>
 
 @interface ABCAliceBobbi : NSObject <RCTBridgeModule>
@@ -511,7 +511,7 @@ end
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/ABCAliceBobbi.m",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.m",
     "theContent": "#import \\"ABCAliceBobbi.h\\"
 
 
@@ -529,7 +529,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/ABCAliceBobbi.xcworkspace/contents.xcworkspacedata",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.xcworkspace/contents.xcworkspacedata",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <Workspace
    version = \\"1.0\\">
@@ -540,7 +540,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/ios/ABCAliceBobbi.xcodeproj/project.pbxproj",
+    "outputFileName": "react-native-alice-bobbi-tmp/ios/ABCAliceBobbi.xcodeproj/project.pbxproj",
     "theContent": "// !$*UTF8*$!
 {
 	archiveVersion = 1;

--- a/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
@@ -3,68 +3,68 @@
 exports[`create alice-bobbi module using mocked lib with config options on Windows 1`] = `
 Array [
   Object {
-    "ensureDir": "react-native-alice-bobbi",
+    "ensureDir": "react-native-alice-bobbi-tmp",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/Properties/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/Properties/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/windows/AliceBobbi/Properties/",
+    "ensureDir": "react-native-alice-bobbi-tmp/windows/AliceBobbi/Properties/",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/README.md",
-    "theContent": "# react-native-alice-bobbi
+    "outputFileName": "react-native-alice-bobbi-tmp/README.md",
+    "theContent": "# react-native-alice-bobbi-tmp
 
 ## Getting started
 
-\`$ npm install react-native-alice-bobbi --save\`
+\`$ npm install react-native-alice-bobbi-tmp --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link react-native-alice-bobbi\`
+\`$ react-native link react-native-alice-bobbi-tmp\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import AliceBobbi from 'react-native-alice-bobbi-tmp';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -72,10 +72,10 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/package.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/package.json",
     "theContent": "{
-  \\"name\\": \\"react-native-alice-bobbi\\",
-  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"name\\": \\"react-native-alice-bobbi-tmp\\",
+  \\"title\\": \\"React Native Alice Bobbi Tmp\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -84,8 +84,8 @@ AliceBobbi;
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi.git\\",
-    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi\\"
+    \\"url\\": \\"git+https://github.com/alicebits/react-native-alice-bobbi-tmp.git\\",
+    \\"baseUrl\\": \\"https://github.com/alicebits/react-native-alice-bobbi-tmp\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -111,7 +111,7 @@ AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/index.js",
+    "outputFileName": "react-native-alice-bobbi-tmp/index.js",
     "theContent": "import { NativeModules } from 'react-native';
 
 const { AliceBobbi } = NativeModules;
@@ -120,7 +120,7 @@ export default AliceBobbi;
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitignore",
     "theContent": "# OSX
 #
 .DS_Store
@@ -133,15 +133,15 @@ yarn-error.log
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
+    "outputFileName": "react-native-alice-bobbi-tmp/.gitattributes",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/.npmignore",
     "theContent": "",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi.sln",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi.sln",
     "theContent": "Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25123.0
@@ -233,7 +233,7 @@ EndGlobal
   ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/.gitignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/.gitignore",
     "theContent": "*AppPackages*
 *BundleArtifacts*
 *ReactAssets*
@@ -315,7 +315,7 @@ packages/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/.npmignore",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/.npmignore",
     "theContent": "
 # Make sure we don't publish build artifacts to NPM
 ARM/
@@ -328,7 +328,7 @@ obj/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/project.json",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/project.json",
     "theContent": "{
   \\"dependencies\\": {
     \\"Microsoft.NETCore.UniversalWindowsPlatform\\": \\"5.2.2\\"
@@ -348,7 +348,7 @@ obj/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/AliceBobbi.csproj",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/AliceBobbi.csproj",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <Project ToolsVersion=\\"14.0\\" DefaultTargets=\\"Build\\" xmlns=\\"http://schemas.microsoft.com/developer/msbuild/2003\\">
   <Import Project=\\"$(MSBuildExtensionsPath)\\\\$(MSBuildToolsVersion)\\\\Microsoft.Common.props\\" Condition=\\"Exists('$(MSBuildExtensionsPath)\\\\$(MSBuildToolsVersion)\\\\Microsoft.Common.props')\\" />
@@ -505,7 +505,7 @@ obj/
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/AliceBobbiModule.cs",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/AliceBobbiModule.cs",
     "theContent": "using ReactNative.Bridge;
 using System;
 using System.Collections.Generic;
@@ -542,7 +542,7 @@ namespace Carol.AliceBobbi
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/AliceBobbiPackage.cs",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/AliceBobbiPackage.cs",
     "theContent": "using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using ReactNative.UIManager;
@@ -599,7 +599,7 @@ namespace Carol.AliceBobbi
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/Properties/AliceBobbi.rd.xml",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/Properties/AliceBobbi.rd.xml",
     "theContent": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <!--
     This file contains Runtime Directives, specifications about types your application accesses
@@ -631,7 +631,7 @@ namespace Carol.AliceBobbi
 ",
   },
   Object {
-    "outputFileName": "react-native-alice-bobbi/windows/AliceBobbi/Properties/AssemblyInfo.cs",
+    "outputFileName": "react-native-alice-bobbi-tmp/windows/AliceBobbi/Properties/AssemblyInfo.cs",
     "theContent": "using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,13 +519,6 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^3.0.0"
 
-ansi-colors@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.1.0.tgz#6374b4dd5d4718ff3ce27a671a3b1cad077132a9"
-  integrity sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==
-  dependencies:
-    ansi-wrap "^0.1.0"
-
 ansi-escapes@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -537,13 +530,6 @@ ansi-escapes@^4.2.1:
   integrity sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==
   dependencies:
     type-fest "^0.5.2"
-
-ansi-gray@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-gray/-/ansi-gray-0.1.1.tgz#2962cf54ec9792c48510a3deb524436861ef7251"
-  integrity sha1-KWLPVOyXksSFEKPetSRDaGHvclE=
-  dependencies:
-    ansi-wrap "0.1.0"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -572,11 +558,6 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
-  integrity sha1-qCJQ3bABXponyoLoLqYDu/pF768=
-
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -596,11 +577,6 @@ aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
-archy@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
-  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -622,34 +598,15 @@ arr-diff@^4.0.0:
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
   integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
-arr-filter@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/arr-filter/-/arr-filter-1.1.2.tgz#43fdddd091e8ef11aa4c45d9cdc18e2dff1711ee"
-  integrity sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=
-  dependencies:
-    make-iterator "^1.0.0"
-
-arr-flatten@^1.0.1, arr-flatten@^1.1.0:
+arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
   integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
-
-arr-map@^2.0.0, arr-map@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/arr-map/-/arr-map-2.0.2.tgz#3a77345ffc1cf35e2a91825601f9e58f2e24cac4"
-  integrity sha1-Onc0X/wc814qkYJWAfnljy4kysQ=
-  dependencies:
-    make-iterator "^1.0.0"
 
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
-
-array-each@^1.0.0, array-each@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
-  integrity sha1-p5SvDAWrF1KEbudTofIRoFugxE8=
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -663,35 +620,6 @@ array-includes@^3.0.3:
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
-
-array-initial@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/array-initial/-/array-initial-1.1.0.tgz#2fa74b26739371c3947bd7a7adc73be334b3d795"
-  integrity sha1-L6dLJnOTccOUe9enrcc74zSz15U=
-  dependencies:
-    array-slice "^1.0.0"
-    is-number "^4.0.0"
-
-array-last@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/array-last/-/array-last-1.3.0.tgz#7aa77073fec565ddab2493f5f88185f404a9d336"
-  integrity sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==
-  dependencies:
-    is-number "^4.0.0"
-
-array-slice@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-1.1.0.tgz#e368ea15f89bc7069f7ffb89aec3a6c7d4ac22d4"
-  integrity sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==
-
-array-sort@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-sort/-/array-sort-1.0.0.tgz#e4c05356453f56f53512a7d1d6123f2c54c0a88a"
-  integrity sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==
-  dependencies:
-    default-compare "^1.0.0"
-    get-value "^2.0.6"
-    kind-of "^5.0.2"
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -720,32 +648,10 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async-done@^1.2.0, async-done@^1.2.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/async-done/-/async-done-1.3.2.tgz#5e15aa729962a4b07414f528a88cdf18e0b290a2"
-  integrity sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.2"
-    process-nextick-args "^2.0.0"
-    stream-exhaust "^1.0.1"
-
-async-each@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
-  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
-
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
-
-async-settle@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async-settle/-/async-settle-1.0.0.tgz#1d0a914bb02575bec8a8f3a74e5080f72b2c0c6b"
-  integrity sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=
-  dependencies:
-    async-done "^1.2.2"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -805,21 +711,6 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
-bach@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/bach/-/bach-1.2.0.tgz#4b3ce96bf27134f79a1b414a51c14e34c3bd9880"
-  integrity sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=
-  dependencies:
-    arr-filter "^1.1.1"
-    arr-flatten "^1.0.1"
-    arr-map "^2.0.0"
-    array-each "^1.0.0"
-    array-initial "^1.0.0"
-    array-last "^1.1.1"
-    async-done "^1.2.2"
-    async-settle "^1.0.0"
-    now-and-later "^2.0.0"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -845,11 +736,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-binary-extensions@^1.0.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
-  integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
-
 boxen@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-3.2.0.tgz#fbdff0de93636ab4450886b6ff45b92d098f45eb"
@@ -872,7 +758,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^2.3.1, braces@^2.3.2:
+braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
@@ -958,11 +844,6 @@ camel-case@^3.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
-camelcase@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
-  integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
-
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -993,25 +874,6 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
-chokidar@^2.0.0:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
-  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
-  dependencies:
-    anymatch "^2.0.0"
-    async-each "^1.0.1"
-    braces "^2.3.2"
-    glob-parent "^3.1.0"
-    inherits "^2.0.3"
-    is-binary-path "^1.0.0"
-    is-glob "^4.0.0"
-    normalize-path "^3.0.0"
-    path-is-absolute "^1.0.0"
-    readdirp "^2.2.1"
-    upath "^1.1.1"
-  optionalDependencies:
-    fsevents "^1.2.7"
 
 chownr@^1.1.1:
   version "1.1.2"
@@ -1049,15 +911,6 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
-
-cliui@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
-  integrity sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wrap-ansi "^2.0.0"
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -1109,15 +962,6 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-collection-map@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/collection-map/-/collection-map-1.0.0.tgz#aea0f06f8d26c780c2b75494385544b2255af18c"
-  integrity sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=
-  dependencies:
-    arr-map "^2.0.2"
-    for-own "^1.0.0"
-    make-iterator "^1.0.0"
-
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -1137,11 +981,6 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
-color-support@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
-  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -1169,16 +1008,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-
-concat-stream@^1.6.0:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
-  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
-  dependencies:
-    buffer-from "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
 
 configstore@^4.0.0:
   version "4.0.0"
@@ -1220,14 +1049,6 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-
-copy-props@^2.0.1:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/copy-props/-/copy-props-2.0.4.tgz#93bb1cadfafd31da5bb8a9d4b41f471ec3a72dfe"
-  integrity sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==
-  dependencies:
-    each-props "^1.3.0"
-    is-plain-object "^2.0.1"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1280,14 +1101,6 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1330,7 +1143,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1, decamelize@^1.2.0:
+decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -1356,18 +1169,6 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
-
-default-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/default-compare/-/default-compare-1.0.0.tgz#cb61131844ad84d84788fb68fd01681ca7781a2f"
-  integrity sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==
-  dependencies:
-    kind-of "^5.0.2"
-
-default-resolution@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/default-resolution/-/default-resolution-2.0.0.tgz#bcb82baa72ad79b426a76732f1a81ad6df26d684"
-  integrity sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=
 
 defer-to-connect@^1.0.1:
   version "1.0.2"
@@ -1412,11 +1213,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-detect-file@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
-  integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
 detect-libc@^1.0.2:
   version "1.0.3"
@@ -1477,14 +1273,6 @@ duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-each-props@^1.3.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/each-props/-/each-props-1.3.2.tgz#ea45a414d16dd5cfa419b1a81720d5ca06892333"
-  integrity sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==
-  dependencies:
-    is-plain-object "^2.0.1"
-    object.defaults "^1.1.0"
-
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -1544,42 +1332,6 @@ es-to-primitive@^1.2.0:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
-
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50:
-  version "0.10.52"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.52.tgz#bb21777e919a04263736ded120a9d665f10ea63f"
-  integrity sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.2"
-    next-tick "~1.0.0"
-
-es6-iterator@^2.0.1, es6-iterator@^2.0.3, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-symbol@^3.1.1, es6-symbol@~3.1.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
-es6-weak-map@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
-  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.1"
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1837,13 +1589,6 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expand-tilde@^2.0.0, expand-tilde@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
-  integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
-  dependencies:
-    homedir-polyfill "^1.0.1"
-
 expect@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
@@ -1855,13 +1600,6 @@ expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
-
-ext@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.2.0.tgz#8dd8d2dd21bcced3045be09621fa0cbf73908ba4"
-  integrity sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==
-  dependencies:
-    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1916,16 +1654,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fancy-log@^1.3.2:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.3.tgz#dbc19154f558690150a23953a0adbd035be45fc7"
-  integrity sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==
-  dependencies:
-    ansi-gray "^0.1.1"
-    color-support "^1.1.3"
-    parse-node-version "^1.0.0"
-    time-stamp "^1.0.0"
-
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
@@ -1977,14 +1705,6 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-find-up@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
-  integrity sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
-  dependencies:
-    path-exists "^2.0.0"
-    pinkie-promise "^2.0.0"
-
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -1998,42 +1718,6 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
-
-findup-sync@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
-  integrity sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=
-  dependencies:
-    detect-file "^1.0.0"
-    is-glob "^3.1.0"
-    micromatch "^3.0.4"
-    resolve-dir "^1.0.1"
-
-findup-sync@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
-  integrity sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==
-  dependencies:
-    detect-file "^1.0.0"
-    is-glob "^4.0.0"
-    micromatch "^3.0.4"
-    resolve-dir "^1.0.1"
-
-fined@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fined/-/fined-1.2.0.tgz#d00beccf1aa2b475d16d423b0238b713a2c4a37b"
-  integrity sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==
-  dependencies:
-    expand-tilde "^2.0.2"
-    is-plain-object "^2.0.3"
-    object.defaults "^1.1.0"
-    object.pick "^1.2.0"
-    parse-filepath "^1.0.1"
-
-flagged-respawn@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
-  integrity sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -2057,17 +1741,10 @@ flush-write-stream@^1.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-for-in@^1.0.1, for-in@^1.0.2:
+for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
-
-for-own@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
-  integrity sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=
-  dependencies:
-    for-in "^1.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -2151,11 +1828,6 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-get-caller-file@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
-  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
-
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -2230,18 +1902,6 @@ glob-stream@^6.1.0:
     to-absolute-glob "^2.0.0"
     unique-stream "^2.0.2"
 
-glob-watcher@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-5.0.3.tgz#88a8abf1c4d131eb93928994bc4a593c2e5dd626"
-  integrity sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==
-  dependencies:
-    anymatch "^2.0.0"
-    async-done "^1.2.0"
-    chokidar "^2.0.0"
-    is-negated-glob "^1.0.0"
-    just-debounce "^1.0.0"
-    object.defaults "^1.1.0"
-
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
@@ -2261,37 +1921,10 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
-global-modules@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
-  integrity sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==
-  dependencies:
-    global-prefix "^1.0.1"
-    is-windows "^1.0.1"
-    resolve-dir "^1.0.0"
-
-global-prefix@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
-  integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
-  dependencies:
-    expand-tilde "^2.0.2"
-    homedir-polyfill "^1.0.1"
-    ini "^1.3.4"
-    is-windows "^1.0.1"
-    which "^1.2.14"
-
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-
-glogg@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/glogg/-/glogg-1.0.2.tgz#2d7dd702beda22eb3bffadf880696da6d846313f"
-  integrity sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==
-  dependencies:
-    sparkles "^1.0.0"
 
 got@^9.6.0:
   version "9.6.0"
@@ -2329,47 +1962,6 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-
-gulp-cli@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/gulp-cli/-/gulp-cli-2.2.0.tgz#5533126eeb7fe415a7e3e84a297d334d5cf70ebc"
-  integrity sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==
-  dependencies:
-    ansi-colors "^1.0.1"
-    archy "^1.0.0"
-    array-sort "^1.0.0"
-    color-support "^1.1.3"
-    concat-stream "^1.6.0"
-    copy-props "^2.0.1"
-    fancy-log "^1.3.2"
-    gulplog "^1.0.0"
-    interpret "^1.1.0"
-    isobject "^3.0.1"
-    liftoff "^3.1.0"
-    matchdep "^2.0.0"
-    mute-stdout "^1.0.0"
-    pretty-hrtime "^1.0.0"
-    replace-homedir "^1.0.0"
-    semver-greatest-satisfied-range "^1.1.0"
-    v8flags "^3.0.1"
-    yargs "^7.1.0"
-
-gulp@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.2.tgz#543651070fd0f6ab0a0650c6a3e6ff5a7cb09caa"
-  integrity sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==
-  dependencies:
-    glob-watcher "^5.0.3"
-    gulp-cli "^2.2.0"
-    undertaker "^1.2.1"
-    vinyl-fs "^3.0.0"
-
-gulplog@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gulplog/-/gulplog-1.0.0.tgz#e28c4d45d05ecbbed818363ce8f9c5926229ffe5"
-  integrity sha1-4oxNRdBey77YGDY86PnFkmIp/+U=
-  dependencies:
-    glogg "^1.0.0"
 
 handlebars@^4.1.2:
   version "4.1.2"
@@ -2452,13 +2044,6 @@ has@^1.0.1, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
-
-homedir-polyfill@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
-  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
-  dependencies:
-    parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -2578,22 +2163,12 @@ inquirer@^7.0.0, inquirer@~7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-interpret@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
-  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
-
 invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
-
-invert-kv@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
-  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
 is-absolute@^1.0.0:
   version "1.0.0"
@@ -2621,13 +2196,6 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
-
-is-binary-path@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
-  integrity sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=
-  dependencies:
-    binary-extensions "^1.0.0"
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -2761,11 +2329,6 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
-is-number@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
-  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
-
 is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
@@ -2778,7 +2341,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -2833,7 +2396,7 @@ is-unc-path@^1.0.0:
   dependencies:
     unc-path-regex "^0.1.2"
 
-is-utf8@^0.2.0, is-utf8@^0.2.1:
+is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
@@ -3415,11 +2978,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-just-debounce@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.0.0.tgz#87fccfaeffc0b68cd19d55f6722943f929ea35ea"
-  integrity sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=
-
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -3441,7 +2999,7 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^5.0.0, kind-of@^5.0.2:
+kind-of@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
@@ -3456,14 +3014,6 @@ kleur@^3.0.2:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-last-run@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/last-run/-/last-run-1.1.1.tgz#45b96942c17b1c79c772198259ba943bebf8ca5b"
-  integrity sha1-RblpQsF7HHnHchmCWbqUO+v4yls=
-  dependencies:
-    default-resolution "^2.0.0"
-    es6-weak-map "^2.0.1"
-
 latest-version@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
@@ -3477,13 +3027,6 @@ lazystream@^1.0.0:
   integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
   dependencies:
     readable-stream "^2.0.5"
-
-lcid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
-  dependencies:
-    invert-kv "^1.0.0"
 
 lead@^1.0.0:
   version "1.0.0"
@@ -3509,31 +3052,6 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-liftoff@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-3.1.0.tgz#c9ba6081f908670607ee79062d700df062c52ed3"
-  integrity sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==
-  dependencies:
-    extend "^3.0.0"
-    findup-sync "^3.0.0"
-    fined "^1.0.1"
-    flagged-respawn "^1.0.0"
-    is-plain-object "^2.0.4"
-    object.map "^1.0.0"
-    rechoir "^0.6.2"
-    resolve "^1.1.7"
-
-load-json-file@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
-  integrity sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
 
 load-json-file@^2.0.0:
   version "2.0.0"
@@ -3647,13 +3165,6 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-iterator@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/make-iterator/-/make-iterator-1.0.1.tgz#29b33f312aa8f547c4a5e490f56afcec99133ad6"
-  integrity sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==
-  dependencies:
-    kind-of "^6.0.2"
-
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3661,7 +3172,7 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-map-cache@^0.2.0, map-cache@^0.2.2:
+map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
@@ -3672,16 +3183,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-matchdep@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/matchdep/-/matchdep-2.0.0.tgz#c6f34834a0d8dbc3b37c27ee8bbcb27c7775582e"
-  integrity sha1-xvNINKDY28OzfCfui7yyfHd1WC4=
-  dependencies:
-    findup-sync "^2.0.0"
-    micromatch "^3.0.4"
-    resolve "^1.4.0"
-    stack-trace "0.0.10"
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -3695,7 +3196,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
+micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -3816,11 +3317,6 @@ mutation-testing-report-schema@^1.0.0, mutation-testing-report-schema@^1.1.1:
   resolved "https://registry.yarnpkg.com/mutation-testing-report-schema/-/mutation-testing-report-schema-1.1.1.tgz#95c4f05c92f5ee4d18978202f47a3de095a14f59"
   integrity sha512-rinrA3i16hHQAE2L0FRinKrIIq1X52LijmeW/EjO3o3gkV5LrG3njGbE6Yezj4/edGBiriJXpLz82hkMG7aKNg==
 
-mute-stdout@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mute-stdout/-/mute-stdout-1.0.1.tgz#acb0300eb4de23a7ddeec014e3e96044b3472331"
-  integrity sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==
-
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
@@ -3866,11 +3362,6 @@ neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
-
-next-tick@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -3952,11 +3443,6 @@ normalize-path@^2.1.1:
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
-
-normalize-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
-  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 normalize-url@^4.1.0:
   version "4.3.0"
@@ -4058,16 +3544,6 @@ object.assign@^4.0.4:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.defaults@^1.0.0, object.defaults@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/object.defaults/-/object.defaults-1.1.0.tgz#3a7f868334b407dea06da16d88d5cd29e435fecf"
-  integrity sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=
-  dependencies:
-    array-each "^1.0.1"
-    array-slice "^1.0.0"
-    for-own "^1.0.0"
-    isobject "^3.0.0"
-
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
@@ -4076,28 +3552,12 @@ object.getownpropertydescriptors@^2.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.5.1"
 
-object.map@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object.map/-/object.map-1.0.1.tgz#cf83e59dc8fcc0ad5f4250e1f78b3b81bd801d37"
-  integrity sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=
-  dependencies:
-    for-own "^1.0.0"
-    make-iterator "^1.0.0"
-
-object.pick@^1.2.0, object.pick@^1.3.0:
+object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
-
-object.reduce@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object.reduce/-/object.reduce-1.0.1.tgz#6fe348f2ac7fa0f95ca621226599096825bb03ad"
-  integrity sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=
-  dependencies:
-    for-own "^1.0.0"
-    make-iterator "^1.0.0"
 
 object.values@^1.1.0:
   version "1.1.0"
@@ -4154,13 +3614,6 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
-os-locale@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
-  integrity sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=
-  dependencies:
-    lcid "^1.0.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -4264,15 +3717,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-filepath@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
-  integrity sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=
-  dependencies:
-    is-absolute "^1.0.0"
-    map-cache "^0.2.0"
-    path-root "^0.1.1"
-
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -4287,16 +3731,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse-node-version@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
-  integrity sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
-
-parse-passwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
-  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
 parse5@4.0.0:
   version "4.0.0"
@@ -4320,13 +3754,6 @@ path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
   integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
-
-path-exists@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
-  integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
-  dependencies:
-    pinkie-promise "^2.0.0"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -4357,27 +3784,6 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
-
-path-root-regex@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
-  integrity sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=
-
-path-root@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
-  integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
-  dependencies:
-    path-root-regex "^0.1.0"
-
-path-type@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
-  integrity sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -4412,18 +3818,6 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
-
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
-  dependencies:
-    pinkie "^2.0.0"
-
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -4475,11 +3869,6 @@ pretty-format@^24.9.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
-
-pretty-hrtime@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
-  integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -4564,14 +3953,6 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-read-pkg-up@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
-  integrity sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=
-  dependencies:
-    find-up "^1.0.0"
-    read-pkg "^1.0.0"
-
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
@@ -4587,15 +3968,6 @@ read-pkg-up@^4.0.0:
   dependencies:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
-
-read-pkg@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
-  integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
-  dependencies:
-    load-json-file "^1.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^1.0.0"
 
 read-pkg@^2.0.0:
   version "2.0.0"
@@ -4615,7 +3987,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -4628,28 +4000,12 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readdirp@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
-  integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
-  dependencies:
-    graceful-fs "^4.1.11"
-    micromatch "^3.1.10"
-    readable-stream "^2.0.2"
-
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
-  dependencies:
-    resolve "^1.1.6"
 
 recursive-readdir@^2.2.2:
   version "2.2.2"
@@ -4708,7 +4064,7 @@ remove-bom-stream@^1.2.0:
     safe-buffer "^5.1.0"
     through2 "^2.0.3"
 
-remove-trailing-separator@^1.0.1, remove-trailing-separator@^1.1.0:
+remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
@@ -4727,15 +4083,6 @@ replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
-
-replace-homedir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/replace-homedir/-/replace-homedir-1.0.0.tgz#e87f6d513b928dde808260c12be7fec6ff6e798c"
-  integrity sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=
-  dependencies:
-    homedir-polyfill "^1.0.1"
-    is-absolute "^1.0.0"
-    remove-trailing-separator "^1.1.0"
 
 request-promise-core@1.1.2:
   version "1.1.2"
@@ -4784,11 +4131,6 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-main-filename@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-  integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
-
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -4800,14 +4142,6 @@ resolve-cwd@^2.0.0:
   integrity sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=
   dependencies:
     resolve-from "^3.0.0"
-
-resolve-dir@^1.0.0, resolve-dir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
-  integrity sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
-  dependencies:
-    expand-tilde "^2.0.0"
-    global-modules "^1.0.0"
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -4835,13 +4169,6 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
-
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.4.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
-  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
-  dependencies:
-    path-parse "^1.0.6"
 
 resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0:
   version "1.11.1"
@@ -4956,13 +4283,6 @@ semver-diff@^2.0.0:
   integrity sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
   dependencies:
     semver "^5.0.3"
-
-semver-greatest-satisfied-range@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz#13e8c2658ab9691cb0cd71093240280d36f77a5b"
-  integrity sha1-E+jCZYq5aRywzXEJMkAoDTb3els=
-  dependencies:
-    sver-compat "^1.5.0"
 
 "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.0"
@@ -5111,11 +4431,6 @@ source-map@~0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sparkles@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"
-  integrity sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
-
 spdx-correct@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
@@ -5169,11 +4484,6 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-stack-trace@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
-
 stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
@@ -5191,11 +4501,6 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
-stream-exhaust@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/stream-exhaust/-/stream-exhaust-1.0.2.tgz#acdac8da59ef2bc1e17a2c0ccf6c320d120e555d"
-  integrity sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==
 
 stream-shift@^1.0.0:
   version "1.0.0"
@@ -5219,7 +4524,7 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
@@ -5291,13 +4596,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-bom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
-  dependencies:
-    is-utf8 "^0.2.0"
-
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -5341,14 +4639,6 @@ surrial@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/surrial/-/surrial-1.0.0.tgz#3ac560cc7038a8ff446920a4f7c3495e1f03a578"
   integrity sha512-dkvhz3QvgraMeFWI9V+BinpNCNoaSNxKcxb0umRpkWeFlZ0WSbIfeTm9YtLA6a4kv/Q2pOMQOtMlcv/b5h6qpg==
-
-sver-compat@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/sver-compat/-/sver-compat-1.5.0.tgz#3cf87dfeb4d07b4a3f14827bc186b3fd0c645cd8"
-  integrity sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=
-  dependencies:
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
 
 symbol-tree@^3.2.2:
   version "3.2.4"
@@ -5425,11 +4715,6 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-time-stamp@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
-  integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -5565,16 +4850,6 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
-  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
-
 typed-inject@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/typed-inject/-/typed-inject-2.0.0.tgz#78fc8b3e27104fb2945c3242d7eff9bc1e5e6320"
@@ -5587,11 +4862,6 @@ typed-rest-client@~1.5.0:
   dependencies:
     tunnel "0.0.4"
     underscore "1.8.3"
-
-typedarray@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 uglify-js@^3.1.4:
   version "3.6.0"
@@ -5610,26 +4880,6 @@ underscore@1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
-
-undertaker-registry@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/undertaker-registry/-/undertaker-registry-1.0.1.tgz#5e4bda308e4a8a2ae584f9b9a4359a499825cc50"
-  integrity sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=
-
-undertaker@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/undertaker/-/undertaker-1.2.1.tgz#701662ff8ce358715324dfd492a4f036055dfe4b"
-  integrity sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==
-  dependencies:
-    arr-flatten "^1.0.1"
-    arr-map "^2.0.0"
-    bach "^1.0.0"
-    collection-map "^1.0.0"
-    es6-weak-map "^2.0.1"
-    last-run "^1.1.0"
-    object.defaults "^1.0.0"
-    object.reduce "^1.0.0"
-    undertaker-registry "^1.0.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -5668,11 +4918,6 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
-
-upath@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
-  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
 update-notifier@^3.0.1:
   version "3.0.1"
@@ -5756,13 +5001,6 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
 
-v8flags@^3.0.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
-  integrity sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==
-  dependencies:
-    homedir-polyfill "^1.0.1"
-
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -5785,7 +5023,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vinyl-fs@^3.0.0, vinyl-fs@^3.0.3:
+vinyl-fs@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-3.0.3.tgz#c85849405f67428feabbbd5c5dbdd64f47d31bc7"
   integrity sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==
@@ -5882,17 +5120,12 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
-which-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
-  integrity sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=
-
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.14, which@^1.2.9, which@^1.3.0:
+which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -5929,14 +5162,6 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
-
-wrap-ansi@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
-  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"
@@ -5999,11 +5224,6 @@ xtend@~4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
-
 y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
@@ -6027,13 +5247,6 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
-  integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
-  dependencies:
-    camelcase "^3.0.0"
-
 yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
@@ -6049,22 +5262,3 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
-
-yargs@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
-  integrity sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=
-  dependencies:
-    camelcase "^3.0.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5785,7 +5785,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vinyl-fs@^3.0.0:
+vinyl-fs@^3.0.0, vinyl-fs@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-3.0.3.tgz#c85849405f67428feabbbd5c5dbdd64f47d31bc7"
   integrity sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,6 +519,13 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^3.0.0"
 
+ansi-colors@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.1.0.tgz#6374b4dd5d4718ff3ce27a671a3b1cad077132a9"
+  integrity sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==
+  dependencies:
+    ansi-wrap "^0.1.0"
+
 ansi-escapes@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -530,6 +537,13 @@ ansi-escapes@^4.2.1:
   integrity sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==
   dependencies:
     type-fest "^0.5.2"
+
+ansi-gray@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-gray/-/ansi-gray-0.1.1.tgz#2962cf54ec9792c48510a3deb524436861ef7251"
+  integrity sha1-KWLPVOyXksSFEKPetSRDaGHvclE=
+  dependencies:
+    ansi-wrap "0.1.0"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -558,6 +572,11 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
+  integrity sha1-qCJQ3bABXponyoLoLqYDu/pF768=
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -566,10 +585,22 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+append-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/append-buffer/-/append-buffer-1.0.2.tgz#d8220cf466081525efea50614f3de6514dfa58f1"
+  integrity sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=
+  dependencies:
+    buffer-equal "^1.0.0"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -591,15 +622,34 @@ arr-diff@^4.0.0:
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
   integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
-arr-flatten@^1.1.0:
+arr-filter@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/arr-filter/-/arr-filter-1.1.2.tgz#43fdddd091e8ef11aa4c45d9cdc18e2dff1711ee"
+  integrity sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=
+  dependencies:
+    make-iterator "^1.0.0"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
   integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+
+arr-map@^2.0.0, arr-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/arr-map/-/arr-map-2.0.2.tgz#3a77345ffc1cf35e2a91825601f9e58f2e24cac4"
+  integrity sha1-Onc0X/wc814qkYJWAfnljy4kysQ=
+  dependencies:
+    make-iterator "^1.0.0"
 
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-each@^1.0.0, array-each@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
+  integrity sha1-p5SvDAWrF1KEbudTofIRoFugxE8=
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -613,6 +663,35 @@ array-includes@^3.0.3:
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
+
+array-initial@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/array-initial/-/array-initial-1.1.0.tgz#2fa74b26739371c3947bd7a7adc73be334b3d795"
+  integrity sha1-L6dLJnOTccOUe9enrcc74zSz15U=
+  dependencies:
+    array-slice "^1.0.0"
+    is-number "^4.0.0"
+
+array-last@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/array-last/-/array-last-1.3.0.tgz#7aa77073fec565ddab2493f5f88185f404a9d336"
+  integrity sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==
+  dependencies:
+    is-number "^4.0.0"
+
+array-slice@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-1.1.0.tgz#e368ea15f89bc7069f7ffb89aec3a6c7d4ac22d4"
+  integrity sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==
+
+array-sort@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-sort/-/array-sort-1.0.0.tgz#e4c05356453f56f53512a7d1d6123f2c54c0a88a"
+  integrity sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==
+  dependencies:
+    default-compare "^1.0.0"
+    get-value "^2.0.6"
+    kind-of "^5.0.2"
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -641,10 +720,32 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+async-done@^1.2.0, async-done@^1.2.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/async-done/-/async-done-1.3.2.tgz#5e15aa729962a4b07414f528a88cdf18e0b290a2"
+  integrity sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.2"
+    process-nextick-args "^2.0.0"
+    stream-exhaust "^1.0.1"
+
+async-each@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
+  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
+
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
+
+async-settle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-settle/-/async-settle-1.0.0.tgz#1d0a914bb02575bec8a8f3a74e5080f72b2c0c6b"
+  integrity sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=
+  dependencies:
+    async-done "^1.2.2"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -704,6 +805,21 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
+bach@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/bach/-/bach-1.2.0.tgz#4b3ce96bf27134f79a1b414a51c14e34c3bd9880"
+  integrity sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=
+  dependencies:
+    arr-filter "^1.1.1"
+    arr-flatten "^1.0.1"
+    arr-map "^2.0.0"
+    array-each "^1.0.0"
+    array-initial "^1.0.0"
+    array-last "^1.1.1"
+    async-done "^1.2.2"
+    async-settle "^1.0.0"
+    now-and-later "^2.0.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -729,6 +845,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-extensions@^1.0.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
+  integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
+
 boxen@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-3.2.0.tgz#fbdff0de93636ab4450886b6ff45b92d098f45eb"
@@ -751,7 +872,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^2.3.1:
+braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
@@ -785,6 +906,11 @@ bser@^2.0.0:
   integrity sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
+  integrity sha1-WWFrSYME1Var1GaWayLu2j7KX74=
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -832,6 +958,11 @@ camel-case@^3.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
+camelcase@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+  integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
+
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -862,6 +993,25 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chokidar@^2.0.0:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
+  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
+  optionalDependencies:
+    fsevents "^1.2.7"
 
 chownr@^1.1.1:
   version "1.1.2"
@@ -900,6 +1050,15 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
+cliui@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+  integrity sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -909,12 +1068,36 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+clone-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
+  integrity sha1-4+JbIHrE5wGvch4staFnksrD3Fg=
+
 clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   dependencies:
     mimic-response "^1.0.0"
+
+clone-stats@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
+  integrity sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=
+
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
+cloneable-readable@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.1.3.tgz#120a00cb053bfb63a222e709f9683ea2e11d8cec"
+  integrity sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==
+  dependencies:
+    inherits "^2.0.1"
+    process-nextick-args "^2.0.0"
+    readable-stream "^2.3.5"
 
 co@^4.6.0:
   version "4.6.0"
@@ -925,6 +1108,15 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collection-map@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-map/-/collection-map-1.0.0.tgz#aea0f06f8d26c780c2b75494385544b2255af18c"
+  integrity sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=
+  dependencies:
+    arr-map "^2.0.2"
+    for-own "^1.0.0"
+    make-iterator "^1.0.0"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -945,6 +1137,11 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-support@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -972,6 +1169,16 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+concat-stream@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 configstore@^4.0.0:
   version "4.0.0"
@@ -1002,10 +1209,25 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+convert-source-map@^1.5.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  dependencies:
+    safe-buffer "~5.1.1"
+
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+copy-props@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/copy-props/-/copy-props-2.0.4.tgz#93bb1cadfafd31da5bb8a9d4b41f471ec3a72dfe"
+  integrity sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==
+  dependencies:
+    each-props "^1.3.0"
+    is-plain-object "^2.0.1"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1058,6 +1280,14 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
+d@1, d@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
+  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
+  dependencies:
+    es5-ext "^0.10.50"
+    type "^1.0.1"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1100,7 +1330,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.2.0:
+decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -1126,6 +1356,18 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+default-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/default-compare/-/default-compare-1.0.0.tgz#cb61131844ad84d84788fb68fd01681ca7781a2f"
+  integrity sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==
+  dependencies:
+    kind-of "^5.0.2"
+
+default-resolution@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-resolution/-/default-resolution-2.0.0.tgz#bcb82baa72ad79b426a76732f1a81ad6df26d684"
+  integrity sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=
 
 defer-to-connect@^1.0.1:
   version "1.0.2"
@@ -1170,6 +1412,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+detect-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
+  integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
 detect-libc@^1.0.2:
   version "1.0.3"
@@ -1220,6 +1467,24 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
+duplexify@^3.6.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
+  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
+each-props@^1.3.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/each-props/-/each-props-1.3.2.tgz#ea45a414d16dd5cfa419b1a81720d5ca06892333"
+  integrity sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==
+  dependencies:
+    is-plain-object "^2.0.1"
+    object.defaults "^1.1.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -1237,6 +1502,13 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+end-of-stream@^1.0.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 end-of-stream@^1.1.0:
   version "1.4.1"
@@ -1272,6 +1544,42 @@ es-to-primitive@^1.2.0:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50:
+  version "0.10.52"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.52.tgz#bb21777e919a04263736ded120a9d665f10ea63f"
+  integrity sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.2"
+    next-tick "~1.0.0"
+
+es6-iterator@^2.0.1, es6-iterator@^2.0.3, es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
+  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
+  dependencies:
+    d "^1.0.1"
+    ext "^1.1.2"
+
+es6-weak-map@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
+  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.46"
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.1"
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1529,6 +1837,13 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 expect@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
@@ -1540,6 +1855,13 @@ expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
+
+ext@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.2.0.tgz#8dd8d2dd21bcced3045be09621fa0cbf73908ba4"
+  integrity sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==
+  dependencies:
+    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1556,7 +1878,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -1593,6 +1915,16 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+fancy-log@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.3.tgz#dbc19154f558690150a23953a0adbd035be45fc7"
+  integrity sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==
+  dependencies:
+    ansi-gray "^0.1.1"
+    color-support "^1.1.3"
+    parse-node-version "^1.0.0"
+    time-stamp "^1.0.0"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -1645,6 +1977,14 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  integrity sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -1658,6 +1998,42 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+findup-sync@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
+  integrity sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^3.1.0"
+    micromatch "^3.0.4"
+    resolve-dir "^1.0.1"
+
+findup-sync@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
+  integrity sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^4.0.0"
+    micromatch "^3.0.4"
+    resolve-dir "^1.0.1"
+
+fined@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fined/-/fined-1.2.0.tgz#d00beccf1aa2b475d16d423b0238b713a2c4a37b"
+  integrity sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==
+  dependencies:
+    expand-tilde "^2.0.2"
+    is-plain-object "^2.0.3"
+    object.defaults "^1.1.0"
+    object.pick "^1.2.0"
+    parse-filepath "^1.0.1"
+
+flagged-respawn@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
+  integrity sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -1673,10 +2049,25 @@ flatted@^2.0.0, flatted@^2.0.1:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-for-in@^1.0.2:
+flush-write-stream@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
+  integrity sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.3.6"
+
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+for-own@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
+  integrity sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=
+  dependencies:
+    for-in "^1.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1715,6 +2106,14 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
+fs-mkdirp-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz#0b7815fc3201c6a69e14db98ce098c16935259eb"
+  integrity sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=
+  dependencies:
+    graceful-fs "^4.1.11"
+    through2 "^2.0.3"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1751,6 +2150,11 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+get-caller-file@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
 get-caller-file@^2.0.1:
   version "2.0.5"
@@ -1795,12 +2199,48 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
 glob-parent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
   integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
   dependencies:
     is-glob "^4.0.1"
+
+glob-stream@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/glob-stream/-/glob-stream-6.1.0.tgz#7045c99413b3eb94888d83ab46d0b404cc7bdde4"
+  integrity sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=
+  dependencies:
+    extend "^3.0.0"
+    glob "^7.1.1"
+    glob-parent "^3.1.0"
+    is-negated-glob "^1.0.0"
+    ordered-read-streams "^1.0.0"
+    pumpify "^1.3.5"
+    readable-stream "^2.1.5"
+    remove-trailing-separator "^1.0.1"
+    to-absolute-glob "^2.0.0"
+    unique-stream "^2.0.2"
+
+glob-watcher@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-5.0.3.tgz#88a8abf1c4d131eb93928994bc4a593c2e5dd626"
+  integrity sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==
+  dependencies:
+    anymatch "^2.0.0"
+    async-done "^1.2.0"
+    chokidar "^2.0.0"
+    is-negated-glob "^1.0.0"
+    just-debounce "^1.0.0"
+    object.defaults "^1.1.0"
 
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
   version "7.1.4"
@@ -1821,10 +2261,37 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  integrity sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
+
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+glogg@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/glogg/-/glogg-1.0.2.tgz#2d7dd702beda22eb3bffadf880696da6d846313f"
+  integrity sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==
+  dependencies:
+    sparkles "^1.0.0"
 
 got@^9.6.0:
   version "9.6.0"
@@ -1843,6 +2310,11 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
+graceful-fs@^4.0.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
@@ -1857,6 +2329,47 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+gulp-cli@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/gulp-cli/-/gulp-cli-2.2.0.tgz#5533126eeb7fe415a7e3e84a297d334d5cf70ebc"
+  integrity sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==
+  dependencies:
+    ansi-colors "^1.0.1"
+    archy "^1.0.0"
+    array-sort "^1.0.0"
+    color-support "^1.1.3"
+    concat-stream "^1.6.0"
+    copy-props "^2.0.1"
+    fancy-log "^1.3.2"
+    gulplog "^1.0.0"
+    interpret "^1.1.0"
+    isobject "^3.0.1"
+    liftoff "^3.1.0"
+    matchdep "^2.0.0"
+    mute-stdout "^1.0.0"
+    pretty-hrtime "^1.0.0"
+    replace-homedir "^1.0.0"
+    semver-greatest-satisfied-range "^1.1.0"
+    v8flags "^3.0.1"
+    yargs "^7.1.0"
+
+gulp@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.2.tgz#543651070fd0f6ab0a0650c6a3e6ff5a7cb09caa"
+  integrity sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==
+  dependencies:
+    glob-watcher "^5.0.3"
+    gulp-cli "^2.2.0"
+    undertaker "^1.2.1"
+    vinyl-fs "^3.0.0"
+
+gulplog@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gulplog/-/gulplog-1.0.0.tgz#e28c4d45d05ecbbed818363ce8f9c5926229ffe5"
+  integrity sha1-4oxNRdBey77YGDY86PnFkmIp/+U=
+  dependencies:
+    glogg "^1.0.0"
 
 handlebars@^4.1.2:
   version "4.1.2"
@@ -1939,6 +2452,13 @@ has@^1.0.1, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+homedir-polyfill@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
+  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
+  dependencies:
+    parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -2029,7 +2549,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2058,12 +2578,30 @@ inquirer@^7.0.0, inquirer@~7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+interpret@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+
 invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
+
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
+
+is-absolute@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576"
+  integrity sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==
+  dependencies:
+    is-relative "^1.0.0"
+    is-windows "^1.0.1"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -2083,6 +2621,13 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-binary-path@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
+  integrity sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=
+  dependencies:
+    binary-extensions "^1.0.0"
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -2150,7 +2695,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.1:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
@@ -2177,6 +2722,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
+  dependencies:
+    is-extglob "^2.1.0"
+
 is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
@@ -2192,6 +2744,11 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
+is-negated-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
+  integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
+
 is-npm@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-3.0.0.tgz#ec9147bfb629c43f494cf67936a961edec7e8053"
@@ -2203,6 +2760,11 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
 is-obj@^1.0.0:
   version "1.0.1"
@@ -2216,7 +2778,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -2234,6 +2796,13 @@ is-regex@^1.0.4:
   integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
+
+is-relative@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-1.0.0.tgz#a1bb6935ce8c5dba1e8b9754b9b2dcc020e2260d"
+  integrity sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==
+  dependencies:
+    is-unc-path "^1.0.0"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -2257,7 +2826,24 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-windows@^1.0.2:
+is-unc-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-1.0.0.tgz#d731e8898ed090a12c352ad2eaed5095ad322c9d"
+  integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
+  dependencies:
+    unc-path-regex "^0.1.2"
+
+is-utf8@^0.2.0, is-utf8@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+
+is-valid-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
+  integrity sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
+
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
@@ -2829,6 +3415,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-debounce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.0.0.tgz#87fccfaeffc0b68cd19d55f6722943f929ea35ea"
+  integrity sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -2850,7 +3441,7 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^5.0.0:
+kind-of@^5.0.0, kind-of@^5.0.2:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
@@ -2865,12 +3456,41 @@ kleur@^3.0.2:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+last-run@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/last-run/-/last-run-1.1.1.tgz#45b96942c17b1c79c772198259ba943bebf8ca5b"
+  integrity sha1-RblpQsF7HHnHchmCWbqUO+v4yls=
+  dependencies:
+    default-resolution "^2.0.0"
+    es6-weak-map "^2.0.1"
+
 latest-version@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
   dependencies:
     package-json "^6.3.0"
+
+lazystream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
+  integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
+  dependencies:
+    readable-stream "^2.0.5"
+
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
+  dependencies:
+    invert-kv "^1.0.0"
+
+lead@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lead/-/lead-1.0.0.tgz#6f14f99a37be3a9dd784f5495690e5903466ee42"
+  integrity sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=
+  dependencies:
+    flush-write-stream "^1.0.2"
 
 left-pad@^1.3.0:
   version "1.3.0"
@@ -2889,6 +3509,31 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+liftoff@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-3.1.0.tgz#c9ba6081f908670607ee79062d700df062c52ed3"
+  integrity sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==
+  dependencies:
+    extend "^3.0.0"
+    findup-sync "^3.0.0"
+    fined "^1.0.1"
+    flagged-respawn "^1.0.0"
+    is-plain-object "^2.0.4"
+    object.map "^1.0.0"
+    rechoir "^0.6.2"
+    resolve "^1.1.7"
+
+load-json-file@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+  integrity sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
 
 load-json-file@^2.0.0:
   version "2.0.0"
@@ -3002,6 +3647,13 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+make-iterator@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/make-iterator/-/make-iterator-1.0.1.tgz#29b33f312aa8f547c4a5e490f56afcec99133ad6"
+  integrity sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==
+  dependencies:
+    kind-of "^6.0.2"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3009,7 +3661,7 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-map-cache@^0.2.2:
+map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
@@ -3020,6 +3672,16 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+matchdep@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/matchdep/-/matchdep-2.0.0.tgz#c6f34834a0d8dbc3b37c27ee8bbcb27c7775582e"
+  integrity sha1-xvNINKDY28OzfCfui7yyfHd1WC4=
+  dependencies:
+    findup-sync "^2.0.0"
+    micromatch "^3.0.4"
+    resolve "^1.4.0"
+    stack-trace "0.0.10"
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -3033,7 +3695,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-micromatch@^3.1.10, micromatch@^3.1.4:
+micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -3154,6 +3816,11 @@ mutation-testing-report-schema@^1.0.0, mutation-testing-report-schema@^1.1.1:
   resolved "https://registry.yarnpkg.com/mutation-testing-report-schema/-/mutation-testing-report-schema-1.1.1.tgz#95c4f05c92f5ee4d18978202f47a3de095a14f59"
   integrity sha512-rinrA3i16hHQAE2L0FRinKrIIq1X52LijmeW/EjO3o3gkV5LrG3njGbE6Yezj4/edGBiriJXpLz82hkMG7aKNg==
 
+mute-stdout@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mute-stdout/-/mute-stdout-1.0.1.tgz#acb0300eb4de23a7ddeec014e3e96044b3472331"
+  integrity sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==
+
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
@@ -3199,6 +3866,11 @@ neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
+next-tick@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -3281,10 +3953,22 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 normalize-url@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.3.0.tgz#9c49e10fc1876aeb76dba88bf1b2b5d9fa57b2ee"
   integrity sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==
+
+now-and-later@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.1.tgz#8e579c8685764a7cc02cb680380e94f43ccb1f7c"
+  integrity sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==
+  dependencies:
+    once "^1.3.2"
 
 npm-bundled@^1.0.1:
   version "1.0.6"
@@ -3352,7 +4036,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.12:
+object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -3364,6 +4048,26 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
+object.assign@^4.0.4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.defaults@^1.0.0, object.defaults@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.defaults/-/object.defaults-1.1.0.tgz#3a7f868334b407dea06da16d88d5cd29e435fecf"
+  integrity sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=
+  dependencies:
+    array-each "^1.0.1"
+    array-slice "^1.0.0"
+    for-own "^1.0.0"
+    isobject "^3.0.0"
+
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
@@ -3372,12 +4076,28 @@ object.getownpropertydescriptors@^2.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.5.1"
 
-object.pick@^1.3.0:
+object.map@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object.map/-/object.map-1.0.1.tgz#cf83e59dc8fcc0ad5f4250e1f78b3b81bd801d37"
+  integrity sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=
+  dependencies:
+    for-own "^1.0.0"
+    make-iterator "^1.0.0"
+
+object.pick@^1.2.0, object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+object.reduce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object.reduce/-/object.reduce-1.0.1.tgz#6fe348f2ac7fa0f95ca621226599096825bb03ad"
+  integrity sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=
+  dependencies:
+    for-own "^1.0.0"
+    make-iterator "^1.0.0"
 
 object.values@^1.1.0:
   version "1.1.0"
@@ -3389,7 +4109,7 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -3423,10 +4143,24 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+ordered-read-streams@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz#77c0cb37c41525d64166d990ffad7ec6a0e1363e"
+  integrity sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=
+  dependencies:
+    readable-stream "^2.0.1"
+
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  integrity sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=
+  dependencies:
+    lcid "^1.0.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -3530,6 +4264,15 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-filepath@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
+  integrity sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=
+  dependencies:
+    is-absolute "^1.0.0"
+    map-cache "^0.2.0"
+    path-root "^0.1.1"
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -3544,6 +4287,16 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse-node-version@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
+  integrity sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
+
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
 parse5@4.0.0:
   version "4.0.0"
@@ -3562,6 +4315,18 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
+
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
+  dependencies:
+    pinkie-promise "^2.0.0"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -3592,6 +4357,27 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+  integrity sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
+  dependencies:
+    path-root-regex "^0.1.0"
+
+path-type@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+  integrity sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -3626,6 +4412,18 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -3678,7 +4476,12 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-process-nextick-args@~2.0.0:
+pretty-hrtime@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
+  integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
+
+process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
@@ -3706,6 +4509,14 @@ psl@^1.1.24, psl@^1.1.28:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.2.0.tgz#df12b5b1b3a30f51c329eacbdef98f3a6e136dc6"
   integrity sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==
 
+pump@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -3713,6 +4524,15 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+pumpify@^1.3.5:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -3744,6 +4564,14 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+read-pkg-up@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+  integrity sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=
+  dependencies:
+    find-up "^1.0.0"
+    read-pkg "^1.0.0"
+
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
@@ -3759,6 +4587,15 @@ read-pkg-up@^4.0.0:
   dependencies:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
+
+read-pkg@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+  integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
+  dependencies:
+    load-json-file "^1.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^1.0.0"
 
 read-pkg@^2.0.0:
   version "2.0.0"
@@ -3778,7 +4615,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -3791,12 +4628,28 @@ readable-stream@^2.0.1, readable-stream@^2.0.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readdirp@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
+  integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    readable-stream "^2.0.2"
+
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
 
 recursive-readdir@^2.2.2:
   version "2.2.2"
@@ -3838,7 +4691,24 @@ registry-url@^5.0.0:
   dependencies:
     rc "^1.2.8"
 
-remove-trailing-separator@^1.0.1:
+remove-bom-buffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz#c2bf1e377520d324f623892e33c10cac2c252b53"
+  integrity sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==
+  dependencies:
+    is-buffer "^1.1.5"
+    is-utf8 "^0.2.1"
+
+remove-bom-stream@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz#05f1a593f16e42e1fb90ebf59de8e569525f9523"
+  integrity sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=
+  dependencies:
+    remove-bom-buffer "^3.0.0"
+    safe-buffer "^5.1.0"
+    through2 "^2.0.3"
+
+remove-trailing-separator@^1.0.1, remove-trailing-separator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
@@ -3852,6 +4722,20 @@ repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+replace-ext@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
+
+replace-homedir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-homedir/-/replace-homedir-1.0.0.tgz#e87f6d513b928dde808260c12be7fec6ff6e798c"
+  integrity sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=
+  dependencies:
+    homedir-polyfill "^1.0.1"
+    is-absolute "^1.0.0"
+    remove-trailing-separator "^1.1.0"
 
 request-promise-core@1.1.2:
   version "1.1.2"
@@ -3900,6 +4784,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-main-filename@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+  integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -3912,6 +4801,14 @@ resolve-cwd@^2.0.0:
   dependencies:
     resolve-from "^3.0.0"
 
+resolve-dir@^1.0.0, resolve-dir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  integrity sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
@@ -3922,6 +4819,13 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+resolve-options@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-options/-/resolve-options-1.1.0.tgz#32bb9e39c06d67338dc9378c0d6d6074566ad131"
+  integrity sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=
+  dependencies:
+    value-or-function "^3.0.0"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -3931,6 +4835,13 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.4.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
 
 resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0:
   version "1.11.1"
@@ -4002,7 +4913,7 @@ safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.1.2:
+safe-buffer@^5.1.0, safe-buffer@^5.1.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
@@ -4045,6 +4956,13 @@ semver-diff@^2.0.0:
   integrity sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
   dependencies:
     semver "^5.0.3"
+
+semver-greatest-satisfied-range@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz#13e8c2658ab9691cb0cd71093240280d36f77a5b"
+  integrity sha1-E+jCZYq5aRywzXEJMkAoDTb3els=
+  dependencies:
+    sver-compat "^1.5.0"
 
 "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.0"
@@ -4193,6 +5111,11 @@ source-map@~0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
+sparkles@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"
+  integrity sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
+
 spdx-correct@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
@@ -4246,6 +5169,11 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+stack-trace@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
 stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
@@ -4264,6 +5192,16 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
+stream-exhaust@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stream-exhaust/-/stream-exhaust-1.0.2.tgz#acdac8da59ef2bc1e17a2c0ccf6c320d120e555d"
+  integrity sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==
+
+stream-shift@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
+  integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
 streamroller@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-2.1.0.tgz#702de4dbba428c82ed3ffc87a75a21a61027e461"
@@ -4281,7 +5219,7 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^1.0.1:
+string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
@@ -4353,6 +5291,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
+strip-bom@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+  integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
+  dependencies:
+    is-utf8 "^0.2.0"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -4396,6 +5341,14 @@ surrial@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/surrial/-/surrial-1.0.0.tgz#3ac560cc7038a8ff446920a4f7c3495e1f03a578"
   integrity sha512-dkvhz3QvgraMeFWI9V+BinpNCNoaSNxKcxb0umRpkWeFlZ0WSbIfeTm9YtLA6a4kv/Q2pOMQOtMlcv/b5h6qpg==
+
+sver-compat@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sver-compat/-/sver-compat-1.5.0.tgz#3cf87dfeb4d07b4a3f14827bc186b3fd0c645cd8"
+  integrity sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=
+  dependencies:
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
 
 symbol-tree@^3.2.2:
   version "3.2.4"
@@ -4452,10 +5405,31 @@ throat@^4.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
+through2-filter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/through2-filter/-/through2-filter-3.0.0.tgz#700e786df2367c2c88cd8aa5be4cf9c1e7831254"
+  integrity sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==
+  dependencies:
+    through2 "~2.0.0"
+    xtend "~4.0.0"
+
+through2@^2.0.0, through2@^2.0.3, through2@~2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+time-stamp@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
+  integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -4468,6 +5442,14 @@ tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
   integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+
+to-absolute-glob@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1865f43d9e74b0822db9f145b78cff7d0f7c849b"
+  integrity sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=
+  dependencies:
+    is-absolute "^1.0.0"
+    is-negated-glob "^1.0.0"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -4503,6 +5485,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+to-through@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-through/-/to-through-2.0.0.tgz#fc92adaba072647bc0b67d6b03664aa195093af6"
+  integrity sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=
+  dependencies:
+    through2 "^2.0.3"
 
 tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"
@@ -4576,6 +5565,16 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
+type@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
+  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+
+type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
+  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
+
 typed-inject@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/typed-inject/-/typed-inject-2.0.0.tgz#78fc8b3e27104fb2945c3242d7eff9bc1e5e6320"
@@ -4589,6 +5588,11 @@ typed-rest-client@~1.5.0:
     tunnel "0.0.4"
     underscore "1.8.3"
 
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
 uglify-js@^3.1.4:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
@@ -4597,10 +5601,35 @@ uglify-js@^3.1.4:
     commander "~2.20.0"
     source-map "~0.6.1"
 
+unc-path-regex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+  integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
+
 underscore@1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
+
+undertaker-registry@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/undertaker-registry/-/undertaker-registry-1.0.1.tgz#5e4bda308e4a8a2ae584f9b9a4359a499825cc50"
+  integrity sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=
+
+undertaker@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/undertaker/-/undertaker-1.2.1.tgz#701662ff8ce358715324dfd492a4f036055dfe4b"
+  integrity sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==
+  dependencies:
+    arr-flatten "^1.0.1"
+    arr-map "^2.0.0"
+    bach "^1.0.0"
+    collection-map "^1.0.0"
+    es6-weak-map "^2.0.1"
+    last-run "^1.1.0"
+    object.defaults "^1.0.0"
+    object.reduce "^1.0.0"
+    undertaker-registry "^1.0.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -4611,6 +5640,14 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
+
+unique-stream@^2.0.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/unique-stream/-/unique-stream-2.3.1.tgz#c65d110e9a4adf9a6c5948b28053d9a8d04cbeac"
+  integrity sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==
+  dependencies:
+    json-stable-stringify-without-jsonify "^1.0.1"
+    through2-filter "^3.0.0"
 
 unique-string@^1.0.0:
   version "1.0.0"
@@ -4631,6 +5668,11 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+upath@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
 update-notifier@^3.0.1:
   version "3.0.1"
@@ -4714,6 +5756,13 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
 
+v8flags@^3.0.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
+  integrity sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -4721,6 +5770,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-or-function@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"
+  integrity sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=
 
 verror@1.10.0:
   version "1.10.0"
@@ -4730,6 +5784,54 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vinyl-fs@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-3.0.3.tgz#c85849405f67428feabbbd5c5dbdd64f47d31bc7"
+  integrity sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==
+  dependencies:
+    fs-mkdirp-stream "^1.0.0"
+    glob-stream "^6.1.0"
+    graceful-fs "^4.0.0"
+    is-valid-glob "^1.0.0"
+    lazystream "^1.0.0"
+    lead "^1.0.0"
+    object.assign "^4.0.4"
+    pumpify "^1.3.5"
+    readable-stream "^2.3.3"
+    remove-bom-buffer "^3.0.0"
+    remove-bom-stream "^1.2.0"
+    resolve-options "^1.1.0"
+    through2 "^2.0.0"
+    to-through "^2.0.0"
+    value-or-function "^3.0.0"
+    vinyl "^2.0.0"
+    vinyl-sourcemap "^1.1.0"
+
+vinyl-sourcemap@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz#92a800593a38703a8cdb11d8b300ad4be63b3e16"
+  integrity sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=
+  dependencies:
+    append-buffer "^1.0.2"
+    convert-source-map "^1.5.0"
+    graceful-fs "^4.1.6"
+    normalize-path "^2.1.1"
+    now-and-later "^2.0.0"
+    remove-bom-buffer "^3.0.0"
+    vinyl "^2.0.0"
+
+vinyl@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.2.0.tgz#d85b07da96e458d25b2ffe19fece9f2caa13ed86"
+  integrity sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==
+  dependencies:
+    clone "^2.1.1"
+    clone-buffer "^1.0.0"
+    clone-stats "^1.0.0"
+    cloneable-readable "^1.0.0"
+    remove-trailing-separator "^1.0.1"
+    replace-ext "^1.0.0"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"
@@ -4780,12 +5882,17 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
+which-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+  integrity sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.9, which@^1.3.0:
+which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -4822,6 +5929,14 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wrap-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"
@@ -4879,6 +5994,16 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xtend@~4.0.0, xtend@~4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+y18n@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+
 y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
@@ -4902,6 +6027,13 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
+  integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
+  dependencies:
+    camelcase "^3.0.0"
+
 yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
@@ -4917,3 +6049,22 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
+  integrity sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=
+  dependencies:
+    camelcase "^3.0.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.2"
+    which-module "^1.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^5.0.0"


### PR DESCRIPTION
Here are some updates to use vinyl-fs to output the generated project artifacts.

The primary purpose is to make it easier for the unit tests to check the output without extra mocking and without using an extra temporary output folder.

This proposal is DRAFT WIP, with generated module name known to be mangled, not tested with generated example project.