### PR TITLE
Issues/120: Use javaCompileProvider in Android template

### DIFF
--- a/templates/android.js
+++ b/templates/android.js
@@ -128,8 +128,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task "jar\${name}"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task "jar\${name}"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -226,8 +226,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -226,8 +226,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -301,8 +301,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -306,8 +306,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -306,8 +306,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -270,8 +270,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -301,8 +301,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -306,8 +306,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -306,8 +306,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -306,8 +306,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -306,8 +306,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -301,8 +301,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -270,8 +270,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -301,8 +301,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -301,8 +301,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -301,8 +301,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -301,8 +301,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -305,8 +305,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -455,8 +455,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -372,8 +372,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -372,8 +372,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -372,8 +372,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -366,8 +366,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task \\"jar\${name}\\"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 


### PR DESCRIPTION
Resolves #120 

`javaCompile` was deprecated in the Android Gradle plugin as of v3.3.0 in favor of `javaCompileProvider` to support lazy task configuration (see [release notes](https://developer.android.com/studio/releases/gradle-plugin)). 

Since the Android Gradle plugin is [currently configured in the template to v3.4.1](https://github.com/brodybits/create-react-native-module/blob/master/templates/android.js#L38) it's safe to just use `javaCompileProvider` directly.