### PR TITLE
support React Native 0.61; drop React Native 0.59

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,8 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
 ### General status
 
 - **React Native versions supported:**
-  - recommended: `0.61`, `0.60` (see known quirks and issues below)
-  - outdated: `0.59`
-- Known quirks & issues on React Native 0.60(+):
-  - [issue #99](https://github.com/brodybits/create-react-native-module/issues/99) - additional `pod install` step needed for RN 0.60 on iOS
-  - [issue #29](https://github.com/brodybits/create-react-native-module/issues/29) - View does not work with RN 0.60 on Android (quick patch needed)
-  - React Native 0.60(+) currently not supported by Expo or react-native-windows
+  - recommended: `0.61`
+  - minimum (outdated): `0.60`
 - Platform fork support
   - tvOS platform fork
     - requires use of `--tvos-enabled` option as documented below

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Options:
   --use-apple-networking                    [iOS] Use `AFNetworking` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                        Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name <exampleName>              Name for the example project (default: `example`)
-  --example-react-native-version <version>  React Native version for the generated example project (default: `react-native@0.59`)
+  --example-react-native-version <version>  React Native version for the generated example project (default: `react-native@0.61`)
   --write-example-podfile                   [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
   -h, --help                                output usage information
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This tool based on [`react-native-create-library`](https://www.npmjs.com/package
     - requires use of `--tvos-enabled` option as documented below
     - requires the [`react-native-tvos`](https://www.npmjs.com/package/react-native-tvos) fork, with minimum version of 0.60 ref:  [react-native-community/react-native-tvos#11](https://github.com/react-native-community/react-native-tvos/issues/11)), [issue #95](https://github.com/brodybits/create-react-native-module/issues/95)
     - unstable with very limited testing, with limited if any active support from the primary maintainer [@brodybits](https://github.com/brodybits) (see [issue #127](https://github.com/brodybits/create-react-native-module/issues/127))
-- Out-of-tree platform support
+- Out-of-tree platforms
+  - not supported by generated example
   - Windows - unstable (not tested, see [issue #23](https://github.com/brodybits/create-react-native-module/issues/23)); now deprecated and may be removed in the near future (see [issue #43](https://github.com/brodybits/create-react-native-module/issues/43))
   - for future consideration: macOS (see [issue #94](https://github.com/brodybits/create-react-native-module/issues/94))
 - Node.js pre-10 support is deprecated and will be removed in the near future (see [issue #38](https://github.com/brodybits/create-react-native-module/issues/38))

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -4,7 +4,7 @@ const normalizedOptions = require('./normalized-options');
 
 const createLibraryModule = require('./lib');
 
-const postCreateInstructions = ({ moduleName, exampleName, writeExamplePodfile }) => {
+const postCreateInstructions = ({ moduleName, exampleName }) => {
   return `
 ====================================================
 YOU'RE ALL SET!
@@ -13,9 +13,6 @@ To build and run iOS example project, do:
 ----
 cd ${moduleName}/${exampleName}
 yarn
-cd ios
-pod install # ${writeExamplePodfile ? `required` : `required starting with React Native 0.60`}
-cd ..
 react-native run-ios
 ----
 `;

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -109,7 +109,7 @@ ${postCreateInstructions(createOptions)}`);
   }, {
     command: '--example-react-native-version [exampleReactNativeVersion]',
     description: 'React Native version for the generated example project',
-    default: 'react-native@0.59',
+    default: 'react-native@0.61',
   }, {
     command: '--write-example-podfile',
     description: '[iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile',

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -29,7 +29,7 @@ const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com';
 const DEFAULT_LICENSE = 'MIT';
 const DEFAULT_GENERATE_EXAMPLE = false;
 const DEFAULT_EXAMPLE_NAME = 'example';
-const DEFAULT_EXAMPLE_REACT_NATIVE_VERSION = 'react-native@0.59';
+const DEFAULT_EXAMPLE_REACT_NATIVE_VERSION = 'react-native@0.61';
 
 const renderTemplateIfValid = (fs, root, template, templateArgs) => {
   // avoid throwing an exception in case there is no valid template.name member

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -235,7 +235,6 @@ const generateWithNormalizedOptions = ({
               console.error('Yarn failure for example, aborting');
               throw (e);
             }
-            commandSync('react-native link', addLinkLibraryOptions);
 
             return resolve();
           });

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -142,6 +142,9 @@ const generateWithNormalizedOptions = ({
       throw new Error(
         `${yarnVersionCommand} failed; ${errorRemedyMessage}`);
     }
+
+    // NOTE: While the pod tool is also required for example on iOS,
+    // react-native CLI will help the user install this tool if needed.
   }
 
   console.info('CREATE: Generating the React Native library module');
@@ -236,6 +239,38 @@ const generateWithNormalizedOptions = ({
               throw (e);
             }
 
+            // Since React Native 0.60, pod install must be done (again)
+            // after adding the native library to the generated example.
+            if (platforms.indexOf('ios') !== -1) {
+              const iosExampleAppProjectPath =
+                `${pathExampleApp}/ios`;
+
+              const podCommandOptions = {
+                cwd: iosExampleAppProjectPath,
+                stdio: 'inherit'
+              };
+
+              // pod tool is needed at this point for iOS
+              try {
+                console.log(
+                  `check for valid pod version in ${iosExampleAppProjectPath}`);
+
+                commandSync('pod --version', podCommandOptions);
+              } catch (e) {
+                console.error('pod --version failure, aborting with broken example app');
+                throw (e);
+              }
+
+              console.log(
+                `running pod install in ${iosExampleAppProjectPath}`);
+
+              try {
+                commandSync('pod install', podCommandOptions);
+              } catch (e) {
+                console.error('pod install failure, aborting with broken example app');
+                throw (e);
+              }
+            }
             return resolve();
           });
         });

--- a/templates/android.js
+++ b/templates/android.js
@@ -203,10 +203,7 @@ public class ${name}Module extends ReactContextBaseJavaModule {
 
 import android.view.View;
 
-// AppCompatCheckBox import for React Native pre-0.60:
-import android.support.v7.widget.AppCompatCheckBox;
-// AppCompatCheckBox import for React Native 0.60(+):
-// import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;

--- a/templates/general.js
+++ b/templates/general.js
@@ -36,11 +36,11 @@ ${name};
 
     const devDependencies =
       `{
-    "react": "^16.8.3",
-    "react-native": "^0.59.10"` +
+    "react": "^16.9.0",
+    "react-native": "^0.61.5"` +
         (withWindows
           ? `,
-    "react-native-windows": "^0.59.0-rc.1"`
+    "react-native-windows": "^0.61.0-beta.5"`
           : ``) + `
   }`;
 

--- a/templates/general.js
+++ b/templates/general.js
@@ -27,10 +27,10 @@ ${name};
     const peerDependencies =
       `{
     "react": "^16.8.1",
-    "react-native": ">=0.59.0-rc.0 <1.0.x"` +
+    "react-native": ">=0.60.0-rc.0 <1.0.x"` +
       (withWindows
         ? `,
-    "react-native-windows": ">=0.59.0-rc.0 <1.0.x"`
+    "react-native-windows": ">=0.60.0-0 <1.0.x"`
         : ``) + `
   }`;
 

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -672,8 +672,8 @@ RCT_EXPORT_MODULE()
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -669,7 +669,7 @@ RCT_EXPORT_MODULE()
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -263,10 +263,7 @@ afterEvaluate { project ->
 
 import android.view.View;
 
-// AppCompatCheckBox import for React Native pre-0.60:
-import android.support.v7.widget.AppCompatCheckBox;
-// AppCompatCheckBox import for React Native 0.60(+):
-// import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -665,7 +665,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -668,8 +668,8 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -21,7 +21,7 @@ Options:
   --use-apple-networking                                      [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name [exampleName]                                Name for the example project (default: \\"example\\")
-  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")
+  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.61\\")
   --write-example-podfile                                     [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
   -h, --help                                                  output usage information"
 `;

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -21,7 +21,7 @@ Options:
   --use-apple-networking                                      [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                                          Generate an example project and links the library module to it, requires both react-native-cli and yarn to be installed globally
   --example-name [exampleName]                                Name for the example project (default: \\"example\\")
-  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.59\\")
+  --example-react-native-version [exampleReactNativeVersion]  React Native version for the generated example project (default: \\"react-native@0.61\\")
   --write-example-podfile                                     [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
   -h, --help                                                  output usage information"
 `;

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -73,7 +73,7 @@ Object {
     },
     Object {
       "command": "--example-react-native-version [exampleReactNativeVersion]",
-      "default": "react-native@0.59",
+      "default": "react-native@0.61",
       "description": "React Native version for the generated example project",
     },
     Object {

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -88,7 +88,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -342,10 +342,7 @@ package com.reactlibrary;
 
 import android.view.View;
 
-// AppCompatCheckBox import for React Native pre-0.60:
-import android.support.v7.widget.AppCompatCheckBox;
-// AppCompatCheckBox import for React Native 0.60(+):
-// import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -91,8 +91,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -782,7 +782,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* execa.commandSync command: react-native init example --version react-native@0.59 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+  "* execa.commandSync command: react-native init example --version react-native@0.61 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -95,8 +95,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -347,10 +347,7 @@ package com.reactlibrary;
 
 import android.view.View;
 
-// AppCompatCheckBox import for React Native pre-0.60:
-import android.support.v7.widget.AppCompatCheckBox;
-// AppCompatCheckBox import for React Native 0.60(+):
-// import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -983,5 +983,9 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
+  "* execa.commandSync command: pod --version options: {\\"cwd\\":\\"./react-native-alice-bobbi/example/ios\\",\\"stdio\\":\\"inherit\\"}
+",
+  "* execa.commandSync command: pod install options: {\\"cwd\\":\\"./react-native-alice-bobbi/example/ios\\",\\"stdio\\":\\"inherit\\"}
+",
 ]
 `;

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -92,7 +92,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -983,7 +983,5 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
-  "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
-",
 ]
 `;

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -95,8 +95,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -983,5 +983,9 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}
 ",
+  "* execa.commandSync command: pod --version options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo/ios\\",\\"stdio\\":\\"inherit\\"}
+",
+  "* execa.commandSync command: pod install options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo/ios\\",\\"stdio\\":\\"inherit\\"}
+",
 ]
 `;

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -983,7 +983,5 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}
 ",
-  "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}
-",
 ]
 `;

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -347,10 +347,7 @@ package com.reactlibrary;
 
 import android.view.View;
 
-// AppCompatCheckBox import for React Native pre-0.60:
-import android.support.v7.widget.AppCompatCheckBox;
-// AppCompatCheckBox import for React Native 0.60(+):
-// import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -92,7 +92,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -78,7 +78,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -81,8 +81,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -311,10 +311,7 @@ package com.reactlibrary;
 
 import android.view.View;
 
-// AppCompatCheckBox import for React Native pre-0.60:
-import android.support.v7.widget.AppCompatCheckBox;
-// AppCompatCheckBox import for React Native 0.60(+):
-// import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;

--- a/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
@@ -78,7 +78,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
@@ -81,8 +81,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -88,7 +88,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -91,8 +91,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
@@ -68,7 +68,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
@@ -71,8 +71,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
@@ -68,7 +68,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
@@ -71,8 +71,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
@@ -68,7 +68,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
@@ -71,8 +71,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
+++ b/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
@@ -85,8 +85,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
+++ b/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
@@ -82,7 +82,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
+++ b/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
@@ -1,0 +1,608 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create alice-bobbi module with example for Android only 1`] = `
+Array [
+  "* execa.commandSync command: react-native --version options: {\\"stdio\\":\\"inherit\\"}
+",
+  "* execa.commandSync command: yarn --version options: {\\"stdio\\":\\"inherit\\"}
+",
+  "* ensureDir dir: react-native-alice-bobbi
+",
+  "* ensureDir dir: react-native-alice-bobbi/
+",
+  "* ensureDir dir: react-native-alice-bobbi/
+",
+  "* ensureDir dir: react-native-alice-bobbi/
+",
+  "* ensureDir dir: react-native-alice-bobbi/
+",
+  "* ensureDir dir: react-native-alice-bobbi/
+",
+  "* ensureDir dir: react-native-alice-bobbi/
+",
+  "* ensureDir dir: react-native-alice-bobbi/android/
+",
+  "* ensureDir dir: react-native-alice-bobbi/android/src/main/
+",
+  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+",
+  "* ensureDir dir: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/
+",
+  "* ensureDir dir: react-native-alice-bobbi/android/
+",
+  "* outputFile name: react-native-alice-bobbi/README.md
+content:
+--------
+# react-native-alice-bobbi
+
+## Getting started
+
+\`$ npm install react-native-alice-bobbi --save\`
+
+### Mostly automatic installation
+
+\`$ react-native link react-native-alice-bobbi\`
+
+## Usage
+\`\`\`javascript
+import AliceBobbi from 'react-native-alice-bobbi';
+
+// TODO: What to do with the module?
+AliceBobbi;
+\`\`\`
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/package.json
+content:
+--------
+{
+  \\"name\\": \\"react-native-alice-bobbi\\",
+  \\"title\\": \\"React Native Alice Bobbi\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"TODO\\",
+  \\"main\\": \\"index.js\\",
+  \\"scripts\\": {
+    \\"test\\": \\"echo \\\\\\"Error: no test specified\\\\\\" && exit 1\\"
+  },
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"git+https://github.com/github_account/react-native-alice-bobbi.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/react-native-alice-bobbi\\"
+  },
+  \\"keywords\\": [
+    \\"react-native\\"
+  ],
+  \\"author\\": {
+    \\"name\\": \\"Your Name\\",
+    \\"email\\": \\"yourname@email.com\\"
+  },
+  \\"license\\": \\"MIT\\",
+  \\"licenseFilename\\": \\"LICENSE\\",
+  \\"readmeFilename\\": \\"README.md\\",
+  \\"peerDependencies\\": {
+    \\"react\\": \\"^16.8.1\\",
+    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+  },
+  \\"devDependencies\\": {
+    \\"react\\": \\"^16.8.3\\",
+    \\"react-native\\": \\"^0.59.10\\"
+  }
+}
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/index.js
+content:
+--------
+import { NativeModules } from 'react-native';
+
+const { AliceBobbi } = NativeModules;
+
+export default AliceBobbi;
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/.gitignore
+content:
+--------
+# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# BUCK
+buck-out/
+\\\\.buckd/
+*.keystore
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/.gitattributes
+content:
+--------
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/.npmignore
+content:
+--------
+example
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/android/build.gradle
+content:
+--------
+// android/build.gradle
+
+// based on:
+//
+// * https://github.com/facebook/react-native/blob/0.60-stable/template/android/build.gradle
+//   original location:
+//   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/build.gradle
+//
+// * https://github.com/facebook/react-native/blob/0.60-stable/template/android/app/build.gradle
+//   original location:
+//   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
+
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
+def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_TARGET_SDK_VERSION = 28
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'maven'
+
+buildscript {
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    // ref: https://docs.gradle.org/current/userguide/tutorial_using_tasks.html#sec:build_script_external_dependencies
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.4.1'
+        }
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'maven'
+
+android {
+    compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+    buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
+    defaultConfig {
+        minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+        targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
+        versionCode 1
+        versionName \\"1.0\\"
+    }
+    lintOptions {
+        abortOnError false
+    }
+}
+
+repositories {
+    // ref: https://www.baeldung.com/maven-local-repository
+    mavenLocal()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url \\"$rootDir/../node_modules/react-native/android\\"
+    }
+    maven {
+        // Android JSC is installed from npm
+        url \\"$rootDir/../node_modules/jsc-android/dist\\"
+    }
+    google()
+    jcenter()
+}
+
+dependencies {
+    //noinspection GradleDynamicVersion
+    implementation 'com.facebook.react:react-native:+'  // From node_modules
+}
+
+def configureReactNativePom(def pom) {
+    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
+
+    pom.project {
+        name packageJson.title
+        artifactId packageJson.name
+        version = packageJson.version
+        group = \\"com.reactlibrary\\"
+        description packageJson.description
+        url packageJson.repository.baseUrl
+
+        licenses {
+            license {
+                name packageJson.license
+                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                distribution 'repo'
+            }
+        }
+
+        developers {
+            developer {
+                id packageJson.author.username
+                name packageJson.author.name
+            }
+        }
+    }
+}
+
+afterEvaluate { project ->
+    // some Gradle build hooks ref:
+    // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
+    task androidJavadoc(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += files(android.bootClasspath)
+        classpath += files(project.getConfigurations().getByName('compile').asList())
+        include '**/*.java'
+    }
+
+    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+        classifier = 'javadoc'
+        from androidJavadoc.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.srcDirs
+        include '**/*.java'
+    }
+
+    android.libraryVariants.all { variant ->
+        def name = variant.name.capitalize()
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task \\"jar\${name}\\"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
+        }
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocJar
+    }
+
+    task installArchives(type: Upload) {
+        configuration = configurations.archives
+        repositories.mavenDeployer {
+            // Deploy to react-native-event-bridge/maven, ready to publish to npm
+            repository url: \\"file://\${projectDir}/../android/maven\\"
+            configureReactNativePom pom
+        }
+    }
+}
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/android/src/main/AndroidManifest.xml
+content:
+--------
+<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+          package=\\"com.reactlibrary\\">
+
+</manifest>
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+content:
+--------
+package com.reactlibrary;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Callback;
+
+public class AliceBobbiModule extends ReactContextBaseJavaModule {
+
+    private final ReactApplicationContext reactContext;
+
+    public AliceBobbiModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        this.reactContext = reactContext;
+    }
+
+    @Override
+    public String getName() {
+        return \\"AliceBobbi\\";
+    }
+
+    @ReactMethod
+    public void sampleMethod(String stringArgument, int numberArgument, Callback callback) {
+        // TODO: Implement some actually useful functionality
+        callback.invoke(\\"Received numberArgument: \\" + numberArgument + \\" stringArgument: \\" + stringArgument);
+    }
+}
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+content:
+--------
+package com.reactlibrary;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
+
+public class AliceBobbiPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Arrays.<NativeModule>asList(new AliceBobbiModule(reactContext));
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/android/README.md
+content:
+--------
+README
+======
+
+If you want to publish the lib as a maven dependency, follow these steps before publishing a new version to npm:
+
+1. Be sure to have the Android [SDK](https://developer.android.com/studio/index.html) and [NDK](https://developer.android.com/ndk/guides/index.html) installed
+2. Be sure to have a \`local.properties\` file in this folder that points to the Android SDK and NDK
+\`\`\`
+ndk.dir=/Users/{username}/Library/Android/sdk/ndk-bundle
+sdk.dir=/Users/{username}/Library/Android/sdk
+\`\`\`
+3. Delete the \`maven\` folder
+4. Run \`./gradlew installArchives\`
+5. Verify that latest set of generated files is in the maven folder with the correct version number
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* execa.commandSync command: react-native init example --version react-native@0.61 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+",
+  "* ensureDir dir: react-native-alice-bobbi/scripts/
+",
+  "* ensureDir dir: react-native-alice-bobbi/example/
+",
+  "* outputFile name: react-native-alice-bobbi/scripts/examples_postinstall.js
+content:
+--------
+#!/usr/bin/env node
+
+  /*
+   * Using libraries within examples and linking them within packages.json like:
+   * \\"react-native-library-name\\": \\"file:../\\"
+   * will cause problems with the metro bundler if the example will run via
+   * \`react-native run-[ios|android]\`. This will result in an error as the metro
+   * bundler will find multiple versions for the same module while resolving it.
+   * The reason for that is that if the library is installed it also copies in the
+   * example folder itself as well as the node_modules folder of the library
+   * although their are defined in .npmignore and should be ignored in theory.
+   *
+   * This postinstall script removes the node_modules folder as well as all
+   * entries from the libraries .npmignore file within the examples node_modules
+   * folder after the library was installed. This should resolve the metro
+   * bundler issue mentioned above.
+   *
+   * It is expected this scripts lives in the libraries root folder within a
+   * scripts folder. As first parameter the relative path to the libraries
+   * folder within the example's node_modules folder may be provided.
+   * This script will determine the path from this project's package.json file
+   * if no such relative path is provided.
+   * An example's package.json entry could look like:
+   * \\"postinstall\\": \\"node ../scripts/examples_postinstall.js node_modules/react-native-library-name/\\"
+   */
+
+  'use strict';
+
+  const fs = require('fs');
+  const path = require('path');
+
+  /// Delete all files and directories for the given path
+  const removeFileDirectoryRecursively = fileDirPath => {
+    // Remove file
+    if (!fs.lstatSync(fileDirPath).isDirectory()) {
+      fs.unlinkSync(fileDirPath);
+      return;
+    }
+
+    // Go down the directory an remove each file / directory recursively
+    fs.readdirSync(fileDirPath).forEach(entry => {
+      const entryPath = path.join(fileDirPath, entry);
+      removeFileDirectoryRecursively(entryPath);
+    });
+    fs.rmdirSync(fileDirPath);
+  };
+
+  /// Remove example/node_modules/react-native-library-name/node_modules directory
+  const removeLibraryNodeModulesPath = (libraryNodeModulesPath) => {
+    const nodeModulesPath = path.resolve(libraryNodeModulesPath, 'node_modules')
+
+    if (!fs.existsSync(nodeModulesPath)) {
+      console.log(\`No node_modules path found at \${nodeModulesPath}. Skipping delete.\`)
+      return;
+    }
+
+    console.log(\`Deleting: \${nodeModulesPath}\`)
+    try {
+      removeFileDirectoryRecursively(nodeModulesPath);
+      console.log(\`Successfully deleted: \${nodeModulesPath}\`)
+    } catch (err) {
+      console.log(\`Error deleting \${nodeModulesPath}: \${err.message}\`);
+    }
+  };
+
+  /// Remove all entries from the .npmignore within  example/node_modules/react-native-library-name/
+  const removeLibraryNpmIgnorePaths = (npmIgnorePath, libraryNodeModulesPath) => {
+    if (!fs.existsSync(npmIgnorePath)) {
+      console.log(\`No .npmignore path found at \${npmIgnorePath}. Skipping deleting content.\`);
+      return;
+    }
+
+    fs.readFileSync(npmIgnorePath, 'utf8').split(/\\\\r?\\\\n/).forEach(entry => {
+      if (entry.length === 0) {
+        return
+      }
+
+      const npmIgnoreLibraryNodeModulesEntryPath = path.resolve(libraryNodeModulesPath, entry);
+      if (!fs.existsSync(npmIgnoreLibraryNodeModulesEntryPath)) {
+        return;
+      }
+
+      console.log(\`Deleting: \${npmIgnoreLibraryNodeModulesEntryPath}\`)
+      try {
+        removeFileDirectoryRecursively(npmIgnoreLibraryNodeModulesEntryPath);
+        console.log(\`Successfully deleted: \${npmIgnoreLibraryNodeModulesEntryPath}\`)
+      } catch (err) {
+        console.log(\`Error deleting \${npmIgnoreLibraryNodeModulesEntryPath}: \${err.message}\`);
+      }
+    });
+  };
+
+  // Main start sweeping process
+  (() => {
+    // Read out dir of example project
+    const exampleDir = process.cwd();
+
+    console.log(\`Starting postinstall cleanup for \${exampleDir}\`);
+
+    // Resolve the React Native library's path within the example's node_modules directory
+    const libraryNodeModulesPath = process.argv.length > 2
+      ? path.resolve(exampleDir, process.argv[2])
+      : path.resolve(exampleDir, 'node_modules', require('../package.json').name);
+
+    console.log(\`Removing unwanted artifacts for \${libraryNodeModulesPath}\`);
+
+    removeLibraryNodeModulesPath(libraryNodeModulesPath);
+
+    const npmIgnorePath = path.resolve(__dirname, '../.npmignore');
+    removeLibraryNpmIgnorePaths(npmIgnorePath, libraryNodeModulesPath);
+  })();
+
+<<<<<<<< ======== >>>>>>>>
+",
+  "* outputFile name: react-native-alice-bobbi/example/App.js
+content:
+--------
+/**
+ * Sample React Native App
+ *
+ * adapted from App.js generated by the following command:
+ *
+ * react-native init example
+ *
+ * https://github.com/facebook/react-native
+ */
+
+import React, { Component } from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
+import AliceBobbi from 'react-native-alice-bobbi';
+
+export default class App extends Component<{}> {
+  state = {
+    status: 'starting',
+    message: '--'
+  };
+  componentDidMount() {
+    AliceBobbi.sampleMethod('Testing', 123, (message) => {
+      this.setState({
+        status: 'native callback received',
+        message
+      });
+    });
+  }
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.welcome}>☆AliceBobbi example☆</Text>
+        <Text style={styles.instructions}>STATUS: {this.state.status}</Text>
+        <Text style={styles.welcome}>☆NATIVE CALLBACK MESSAGE☆</Text>
+        <Text style={styles.instructions}>{this.state.message}</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+});
+
+<<<<<<<< ======== >>>>>>>>
+",
+  Object {
+    "call": "fs.readFileSync",
+    "jsonFilePath": "./react-native-alice-bobbi/example/package.json",
+  },
+  Object {
+    "call": "fs.writeFileSync",
+    "filePath": "./react-native-alice-bobbi/example/package.json",
+    "json": "{
+  \\"name\\": \\"example\\",
+  \\"scripts\\": {
+    \\"test\\": \\"echo 'not implemented' && exit 1\\",
+    \\"postinstall\\": \\"node ../scripts/examples_postinstall.js\\"
+  }
+}
+",
+    "options": Object {
+      "fs": Object {
+        "ensureDir": [Function],
+        "outputFile": [Function],
+        "readFileSync": [Function],
+        "writeFileSync": [Function],
+      },
+      "spaces": 2,
+    },
+  },
+  "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
+",
+]
+`;

--- a/tests/with-injection/create/with-example/for-android-only/create-with-example-for-android-only.test.js
+++ b/tests/with-injection/create/with-example/for-android-only/create-with-example-for-android-only.test.js
@@ -1,0 +1,18 @@
+const lib = require('../../../../../lib/lib.js');
+
+const ioInject = require('../../../helpers/io-inject.js');
+
+test('create alice-bobbi module with example for Android only', () => {
+  const mysnap = [];
+
+  const inject = ioInject(mysnap);
+
+  const options = {
+    name: 'alice-bobbi',
+    generateExample: true,
+    platforms: 'android'
+  };
+
+  return lib(options, inject)
+    .then(() => { expect(mysnap).toMatchSnapshot(); });
+});

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -775,7 +775,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* execa.commandSync command: react-native init example --version react-native@0.59 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+  "* execa.commandSync command: react-native init example --version react-native@0.61 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -95,8 +95,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -988,7 +988,5 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
-  "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
-",
 ]
 `;

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -988,5 +988,9 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
+  "* execa.commandSync command: pod --version options: {\\"cwd\\":\\"./react-native-alice-bobbi/example/ios\\",\\"stdio\\":\\"inherit\\"}
+",
+  "* execa.commandSync command: pod install options: {\\"cwd\\":\\"./react-native-alice-bobbi/example/ios\\",\\"stdio\\":\\"inherit\\"}
+",
 ]
 `;

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -92,7 +92,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -775,7 +775,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* execa.commandSync command: react-native init example --version react-native@0.59 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+  "* execa.commandSync command: react-native init example --version react-native@0.61 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -95,8 +95,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -988,7 +988,5 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
-  "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
-",
 ]
 `;

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -988,5 +988,9 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
+  "* execa.commandSync command: pod --version options: {\\"cwd\\":\\"./react-native-alice-bobbi/example/ios\\",\\"stdio\\":\\"inherit\\"}
+",
+  "* execa.commandSync command: pod install options: {\\"cwd\\":\\"./react-native-alice-bobbi/example/ios\\",\\"stdio\\":\\"inherit\\"}
+",
 ]
 `;

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -92,7 +92,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -775,7 +775,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* execa.commandSync command: react-native init example --version react-native@0.59 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
+  "* execa.commandSync command: react-native init example --version react-native@0.61 options: {\\"cwd\\":\\"./react-native-alice-bobbi\\",\\"stdio\\":\\"inherit\\"}
 ",
   "* ensureDir dir: react-native-alice-bobbi/scripts/
 ",

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -95,8 +95,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -988,7 +988,5 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
-  "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
-",
 ]
 `;

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -988,5 +988,9 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/example\\",\\"stdio\\":\\"inherit\\"}
 ",
+  "* execa.commandSync command: pod --version options: {\\"cwd\\":\\"./react-native-alice-bobbi/example/ios\\",\\"stdio\\":\\"inherit\\"}
+",
+  "* execa.commandSync command: pod install options: {\\"cwd\\":\\"./react-native-alice-bobbi/example/ios\\",\\"stdio\\":\\"inherit\\"}
+",
 ]
 `;

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -92,7 +92,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -95,8 +95,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -1033,5 +1033,9 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}
 ",
+  "* execa.commandSync command: pod --version options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo/ios\\",\\"stdio\\":\\"inherit\\"}
+",
+  "* execa.commandSync command: pod install options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo/ios\\",\\"stdio\\":\\"inherit\\"}
+",
 ]
 `;

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -1033,7 +1033,5 @@ const styles = StyleSheet.create({
   },
   "* execa.commandSync command: yarn add file:../ options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}
 ",
-  "* execa.commandSync command: react-native link options: {\\"cwd\\":\\"./react-native-alice-bobbi/test-demo\\",\\"stdio\\":\\"inherit\\"}
-",
 ]
 `;

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -92,7 +92,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -88,7 +88,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -91,8 +91,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -78,7 +78,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -81,8 +81,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -78,7 +78,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -81,8 +81,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -88,7 +88,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -91,8 +91,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -88,7 +88,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -91,8 +91,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -88,7 +88,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -91,8 +91,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -88,7 +88,7 @@ content:
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -91,8 +91,8 @@ content:
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -158,9 +158,6 @@ To build and run iOS example project, do:
 ----
 cd react-native-alice-bobbi/undefined
 yarn
-cd ios
-pod install # required starting with React Native 0.60
-cd ..
 react-native run-ios
 ----
 ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -106,7 +106,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -109,8 +109,8 @@ AliceBobbi;
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -158,9 +158,6 @@ To build and run iOS example project, do:
 ----
 cd react-native-alice-bobbi/undefined
 yarn
-cd ios
-pod install # required starting with React Native 0.60
-cd ..
 react-native run-ios
 ----
 ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -106,7 +106,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -109,8 +109,8 @@ AliceBobbi;
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -48,9 +48,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:150:15)
-    at generateLibraryModule (.../lib/lib.js:244:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:261:10)
+    at ensureDir (.../lib/lib.js:153:15)
+    at generateLibraryModule (.../lib/lib.js:279:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:296:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -49,8 +49,8 @@ Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
     at ensureDir (.../lib/lib.js:150:15)
-    at generateLibraryModule (.../lib/lib.js:245:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:262:10)
+    at generateLibraryModule (.../lib/lib.js:244:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:261:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -102,7 +102,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -105,8 +105,8 @@ AliceBobbi;
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -273,7 +273,7 @@ TestPackage;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -165,7 +165,7 @@ Array [
         "--example-react-native-version [exampleReactNativeVersion]",
         "React Native version for the generated example project",
         [Function],
-        "react-native@0.59",
+        "react-native@0.61",
       ],
     },
   },

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -276,8 +276,8 @@ TestPackage;
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -163,7 +163,7 @@ Array [
         "--example-react-native-version [exampleReactNativeVersion]",
         "React Native version for the generated example project",
         [Function],
-        "react-native@0.59",
+        "react-native@0.61",
       ],
     },
   },

--- a/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
@@ -99,8 +99,8 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\",
-    \\"react-native-windows\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\",
+    \\"react-native-windows\\": \\">=0.60.0-0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-defaults/for-windows/__snapshots__/create-with-defaults-for-windows.test.js.snap
@@ -103,9 +103,9 @@ AliceBobbi;
     \\"react-native-windows\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\",
-    \\"react-native-windows\\": \\"^0.59.0-rc.1\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\",
+    \\"react-native-windows\\": \\"^0.61.0-beta.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -168,7 +168,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -1056,12 +1056,5 @@ const styles = StyleSheet.create({
       "stdio": "inherit",
     },
   },
-  Object {
-    "commandSync": "react-native link",
-    "options": Object {
-      "cwd": "./react-native-alice-bobbi/example",
-      "stdio": "inherit",
-    },
-  },
 ]
 `;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -1056,5 +1056,29 @@ const styles = StyleSheet.create({
       "stdio": "inherit",
     },
   },
+  Object {
+    "log": Array [
+      "check for valid pod version in ./react-native-alice-bobbi/example/ios",
+    ],
+  },
+  Object {
+    "commandSync": "pod --version",
+    "options": Object {
+      "cwd": "./react-native-alice-bobbi/example/ios",
+      "stdio": "inherit",
+    },
+  },
+  Object {
+    "log": Array [
+      "running pod install in ./react-native-alice-bobbi/example/ios",
+    ],
+  },
+  Object {
+    "commandSync": "pod install",
+    "options": Object {
+      "cwd": "./react-native-alice-bobbi/example/ios",
+      "stdio": "inherit",
+    },
+  },
 ]
 `;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -171,8 +171,8 @@ AliceBobbi;
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -824,11 +824,11 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   Object {
     "info": Array [
-      "CREATE example app with the following command: react-native init example --version react-native@0.59",
+      "CREATE example app with the following command: react-native init example --version react-native@0.61",
     ],
   },
   Object {
-    "commandSync": "react-native init example --version react-native@0.59",
+    "commandSync": "react-native init example --version react-native@0.61",
     "options": Object {
       "cwd": "./react-native-alice-bobbi",
       "stdio": "inherit",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -168,7 +168,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -171,8 +171,8 @@ AliceBobbi;
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -824,11 +824,11 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   Object {
     "info": Array [
-      "CREATE example app with the following command: react-native init example --version react-native@0.59",
+      "CREATE example app with the following command: react-native init example --version react-native@0.61",
     ],
   },
   Object {
-    "commandSync": "react-native init example --version react-native@0.59",
+    "commandSync": "react-native init example --version react-native@0.61",
     "options": Object {
       "cwd": "./react-native-alice-bobbi",
       "stdio": "inherit",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -168,7 +168,7 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -1056,12 +1056,5 @@ const styles = StyleSheet.create({
       "stdio": "inherit",
     },
   },
-  Object {
-    "commandSync": "react-native link",
-    "options": Object {
-      "cwd": "./react-native-alice-bobbi/example",
-      "stdio": "inherit",
-    },
-  },
 ]
 `;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -1056,5 +1056,29 @@ const styles = StyleSheet.create({
       "stdio": "inherit",
     },
   },
+  Object {
+    "log": Array [
+      "check for valid pod version in ./react-native-alice-bobbi/example/ios",
+    ],
+  },
+  Object {
+    "commandSync": "pod --version",
+    "options": Object {
+      "cwd": "./react-native-alice-bobbi/example/ios",
+      "stdio": "inherit",
+    },
+  },
+  Object {
+    "log": Array [
+      "running pod install in ./react-native-alice-bobbi/example/ios",
+    ],
+  },
+  Object {
+    "commandSync": "pod install",
+    "options": Object {
+      "cwd": "./react-native-alice-bobbi/example/ios",
+      "stdio": "inherit",
+    },
+  },
 ]
 `;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -171,8 +171,8 @@ AliceBobbi;
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -824,11 +824,11 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   Object {
     "info": Array [
-      "CREATE example app with the following command: react-native init example --version react-native@0.59",
+      "CREATE example app with the following command: react-native init example --version react-native@0.61",
     ],
   },
   Object {
-    "commandSync": "react-native init example --version react-native@0.59",
+    "commandSync": "react-native init example --version react-native@0.61",
     "options": Object {
       "cwd": "./react-native-alice-bobbi",
       "stdio": "inherit",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -818,11 +818,11 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
   },
   Object {
     "info": Array [
-      "CREATE example app with the following command: react-native init example --version react-native@0.59",
+      "CREATE example app with the following command: react-native init example --version react-native@0.61",
     ],
   },
   Object {
-    "commandSync": "react-native init example --version react-native@0.59",
+    "commandSync": "react-native init example --version react-native@0.61",
     "options": Object {
       "cwd": "./react-native-alice-bobbi",
       "stdio": "inherit",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -1050,5 +1050,29 @@ const styles = StyleSheet.create({
       "stdio": "inherit",
     },
   },
+  Object {
+    "log": Array [
+      "check for valid pod version in ./react-native-alice-bobbi/example/ios",
+    ],
+  },
+  Object {
+    "commandSync": "pod --version",
+    "options": Object {
+      "cwd": "./react-native-alice-bobbi/example/ios",
+      "stdio": "inherit",
+    },
+  },
+  Object {
+    "log": Array [
+      "running pod install in ./react-native-alice-bobbi/example/ios",
+    ],
+  },
+  Object {
+    "commandSync": "pod install",
+    "options": Object {
+      "cwd": "./react-native-alice-bobbi/example/ios",
+      "stdio": "inherit",
+    },
+  },
 ]
 `;

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -162,7 +162,7 @@ ABCAliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -165,8 +165,8 @@ ABCAliceBobbi;
     \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\"
   }
 }
 ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -1050,12 +1050,5 @@ const styles = StyleSheet.create({
       "stdio": "inherit",
     },
   },
-  Object {
-    "commandSync": "react-native link",
-    "options": Object {
-      "cwd": "./react-native-alice-bobbi/example",
-      "stdio": "inherit",
-    },
-  },
 ]
 `;

--- a/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
@@ -99,8 +99,8 @@ AliceBobbi;
   \\"readmeFilename\\": \\"README.md\\",
   \\"peerDependencies\\": {
     \\"react\\": \\"^16.8.1\\",
-    \\"react-native\\": \\">=0.59.0-rc.0 <1.0.x\\",
-    \\"react-native-windows\\": \\">=0.59.0-rc.0 <1.0.x\\"
+    \\"react-native\\": \\">=0.60.0-rc.0 <1.0.x\\",
+    \\"react-native-windows\\": \\">=0.60.0-0 <1.0.x\\"
   },
   \\"devDependencies\\": {
     \\"react\\": \\"^16.9.0\\",

--- a/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
+++ b/tests/with-mocks/lib/create/with-options/for-windows/__snapshots__/create-with-options-for-windows.test.js.snap
@@ -103,9 +103,9 @@ AliceBobbi;
     \\"react-native-windows\\": \\">=0.59.0-rc.0 <1.0.x\\"
   },
   \\"devDependencies\\": {
-    \\"react\\": \\"^16.8.3\\",
-    \\"react-native\\": \\"^0.59.10\\",
-    \\"react-native-windows\\": \\"^0.59.0-rc.1\\"
+    \\"react\\": \\"^16.9.0\\",
+    \\"react-native\\": \\"^0.61.5\\",
+    \\"react-native-windows\\": \\"^0.61.0-beta.5\\"
   }
 }
 ",


### PR DESCRIPTION
Major (breaking) updates for new 0.x release:

* generate example with React Native 0.61 by default
* remove `react-native link` step (not needed since React Native 0.60)
* prep: test with generate example for Android only
  _(needed to ensure `pod install` is not run on example in case the module is for Android only)_
* do `pod install` in generated example for iOS
* remove `pod install` step from manual post-create instructions
* update generated Android view for React Native 0.60(+)
* update template `devDependencies` for React Native 0.61
* minimum React Native 0.60 in template `peerDependencies`
* documentation updates
* update documentation for out-of-tree platforms
  (not supported by the generated example)

__Tested as follows:__

- [x] _library module with generated example working on RN 0.61 on Android & iOS_
- [x] _view module with generated example working on RN 0.61 on Android & iOS_
- [x] _library module with generated example working on RN 0.60 on Android & iOS_
- [x] _view module with generated example working on RN 0.60 on Android & iOS_

resolves #29
resolves #93
resolves #99
resolves #132
closes #130
closes #192