### PR TITLE
no log of generated example options unless enabled

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -109,10 +109,12 @@ const generateWithNormalizedOptions = ({
   license: ${license}
   view: ${view}
   useAppleNetworking: ${useAppleNetworking}
+` + (generateExample
+      ? `
   generateExample: ${generateExample}
   exampleName: ${exampleName}
   writeExamplePodfile: ${writeExamplePodfile}
-  `);
+` : ``));
 
   // QUICK LOCAL INJECTION overwite of existing execSync / commandSync call from
   // mockable execa object for now (at least):

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -25,10 +25,7 @@ Array [
   license: MIT
   view: false
   useAppleNetworking: false
-  generateExample: false
-  exampleName: example
-  writeExamplePodfile: false
-  ",
+",
     ],
   },
   Object {

--- a/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -25,10 +25,7 @@ Array [
   license: MIT
   view: false
   useAppleNetworking: false
-  generateExample: false
-  exampleName: example
-  writeExamplePodfile: false
-  ",
+",
     ],
   },
   Object {

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -25,10 +25,7 @@ Array [
   license: MIT
   view: false
   useAppleNetworking: false
-  generateExample: false
-  exampleName: example
-  writeExamplePodfile: false
-  ",
+",
     ],
   },
   Object {
@@ -48,9 +45,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:153:15)
-    at generateLibraryModule (.../lib/lib.js:279:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:296:10)
+    at ensureDir (.../lib/lib.js:155:15)
+    at generateLibraryModule (.../lib/lib.js:281:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:298:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -25,10 +25,11 @@ Array [
   license: MIT
   view: false
   useAppleNetworking: false
+
   generateExample: true
   exampleName: example
   writeExamplePodfile: false
-  ",
+",
     ],
   },
   Object {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -25,10 +25,11 @@ Array [
   license: MIT
   view: false
   useAppleNetworking: false
+
   generateExample: true
   exampleName: example
   writeExamplePodfile: false
-  ",
+",
     ],
   },
   Object {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -25,10 +25,11 @@ Array [
   license: MIT
   view: false
   useAppleNetworking: false
+
   generateExample: true
   exampleName: example
   writeExamplePodfile: false
-  ",
+",
     ],
   },
   Object {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -19,10 +19,11 @@ Array [
   license: ISC
   view: false
   useAppleNetworking: false
+
   generateExample: true
   exampleName: example
   writeExamplePodfile: false
-  ",
+",
     ],
   },
   Object {


### PR DESCRIPTION
(and add a little extra spacing in the process)

Rationale: a higher-level interactive utility such as [`brodybits/react-native-module-init`](https://github.com/brodybits/react-native-module-init) may want to offer its own way to add a generated example.

This update removes some unwanted log output from [`brodybits/react-native-module-init`](https://github.com/brodybits/react-native-module-init) discussed in:

- <https://github.com/brodybits/react-native-module-init/issues/9>
- proposed update in <https://github.com/brodybits/react-native-module-init/pull/8>