### PR TITLE
log more example app info in the end

### DIFF
--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -1,11 +1,14 @@
 const emoji = require('node-emoji');
 
+const logSymbols = require('log-symbols');
+
 const normalizedOptions = require('./normalized-options');
 
 const createLibraryModule = require('./lib');
 
 const postCreateInstructions = ({
   moduleName,
+  platforms,
   generateExample,
   exampleName
 }) => `
@@ -13,12 +16,21 @@ const postCreateInstructions = ({
 YOU'RE ALL SET!
 ` + (generateExample
     ? `
-To build and run iOS example project, do:
-----
-cd ${moduleName}/${exampleName}
-yarn
-react-native run-ios
-----
+${emoji.get('bulb')} check out the example app in ${moduleName}/${exampleName}
+${emoji.get('bulb')} recommended: run Metro Bundler in a new shell
+${logSymbols.info} (cd ${moduleName}/${exampleName} && yarn start)
+${emoji.get('bulb')} enter the following commands to run the example app:
+${logSymbols.info} cd ${moduleName}/${exampleName}
+${platforms.split(',').map(platform =>
+  `${logSymbols.info} react-native run-${platform}`
+).join(`
+`)}
+${logSymbols.warning} first steps in case of a clean checkout
+${logSymbols.info} run Yarn in ${moduleName}/${exampleName}/ios
+${logSymbols.info} (cd ${moduleName}/${exampleName} && yarn)
+${logSymbols.info} do \`pod install\` for iOS in ${moduleName}/${exampleName}/ios
+${logSymbols.info} cd ${moduleName}/${exampleName}
+${logSymbols.info} (cd ios && pod install)
 `
     : `
 ${emoji.get('bulb')} next time consider using \`--generate-example\` to add a generated example!

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "execa": "^3.3.0",
     "fs-extra": "^8.1.0",
     "jsonfile": "^6.0.0",
+    "log-symbols": "^3.0.0",
     "node-emoji": "^1.10.0",
     "param-case": "^2.1.1",
     "pascal-case": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,6 +3148,13 @@ lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+log-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
+
 log4js@~6.1.0:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.1.2.tgz#04688e1f4b8080c127b7dccb0db1c759cbb25dc4"


### PR DESCRIPTION
with some symbols from `log-symbols`

based on logs from this interactive CLI tool:

- https://github.com/brodybits/react-native-module-init

Some final output from testing in my workarea:

```
💡 check out the example app in react-native-awesome-module/example
💡 recommended: run Metro Bundler in a new shell
ℹ (cd react-native-awesome-module/example && yarn start)
💡 enter the following commands to run the example app:
ℹ cd react-native-awesome-module/example
ℹ react-native run-ios
ℹ react-native run-android
⚠ first steps in case of a clean checkout
ℹ run Yarn in react-native-awesome-module/example/ios
ℹ (cd react-native-awesome-module/example && yarn)
ℹ do `pod install` for iOS in react-native-awesome-module/example/ios
ℹ cd react-native-awesome-module/example
ℹ (cd ios && pod install)
```