### PR TITLE
refactoring: move require('uuid') out of templates

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -12,6 +12,8 @@ const fsExtra = require('fs-extra');
 
 const jsonfile = require('jsonfile');
 
+const uuidV1 = require('uuid').v1;
+
 // Internal imports:
 
 const normalizedOptions = require('./normalized-options');
@@ -151,6 +153,11 @@ const generateWithNormalizedOptions = ({
 
   console.info('CREATE: Generating the React Native library module');
 
+  // uuid (v1) for Windows only for now (at least)
+  const uuid = (platforms.indexOf('windows') !== -1)
+    ? uuidV1().toUpperCase()
+    : null;
+
   const generateLibraryModule = () => {
     return fs.ensureDir(moduleName).then(() => {
       return Promise.all(templates.filter((template) => {
@@ -173,6 +180,7 @@ const generateWithNormalizedOptions = ({
           license,
           view,
           useAppleNetworking,
+          uuid,
           generateExample,
           exampleName,
         };

--- a/templates/windows.js
+++ b/templates/windows.js
@@ -1,8 +1,6 @@
-const uuid = require('uuid').v1().toUpperCase();
-
 module.exports = platform => [{
   name: ({ name }) => `${platform}/${name}.sln`,
-  content: ({ name }) =>
+  content: ({ name, uuid }) =>
     `Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25123.0
@@ -209,7 +207,7 @@ obj/
 `,
 }, {
   name: ({ name }) => `${platform}/${name}/${name}.csproj`,
-  content: ({ name, namespace }) =>
+  content: ({ name, namespace, uuid }) =>
     `<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\\$(MSBuildToolsVersion)\\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\\$(MSBuildToolsVersion)\\Microsoft.Common.props')" />

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -45,9 +45,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:155:15)
-    at generateLibraryModule (.../lib/lib.js:281:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:298:10)
+    at ensureDir (.../lib/lib.js:162:15)
+    at generateLibraryModule (.../lib/lib.js:289:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:306:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",


### PR DESCRIPTION
(templates/windows.js)

rationale: it is desired to move templates/windows.js into
an "unsupported" directory tree, and then test it using
uuid from devDependencies, in the near future

✅ `npm test` is ok