### PR TITLE
updates to setup of Stryker Mutator

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "jest": "jest",
     "lint": "eslint .",
-    "run-stryker": "stryker run",
+    "stryker": "stryker run",
     "test": "npm run lint && npm run jest"
   },
   "repository": {

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -2,6 +2,10 @@ module.exports = config => {
   config.set({
     mutator: 'javascript',
     mutate: [
+      // TBD there seems to be an issue with
+      // Stryker mutation testing on
+      // bin/*.js  (...)
+      // 'bin/**/*.js',
       'lib/**/*.js',
       'templates/**/*.js',
       'unsupported-platforms/**/*.js'

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -7,7 +7,11 @@ module.exports = config => {
       'unsupported-platforms/**/*.js'
     ],
     packageManager: 'yarn',
-    reporters: ['html', 'clear-text', 'progress'],
+    reporters: [
+      'html',
+      'clear-text',
+      'progress'
+    ],
     testRunner: 'jest',
     transpilers: [],
     coverageAnalysis: 'off'

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,7 +1,11 @@
 module.exports = config => {
   config.set({
     mutator: 'javascript',
-    mutate: ['lib/**/*.js', 'templates/**/*.js', 'unsupported-platforms/**/*.js'],
+    mutate: [
+      'lib/**/*.js',
+      'templates/**/*.js',
+      'unsupported-platforms/**/*.js'
+    ],
     packageManager: 'yarn',
     reporters: ['html', 'clear-text', 'progress'],
     testRunner: 'jest',


### PR DESCRIPTION
- renamed `stryker` scripts entry in `package.json`
- split `mutate` configuration into multiple lines in `stryker.conf.js`
- split `reporters` configuration into multiple lines in `stryker.conf.js`
- TBD commented out for now: add `bin/**/*.js` to mutate configuration in `stryker.conf.js` (there seems to be an issue to be investigated with Stryker mutation testing on `bin/*.js`)

✅ `npm test` ok
✅ `yarn stryker` command starts running Stryker mutation testing which shows the limited number of surviving mutants in the end and generates the HTML report as enabled by the configuration