### PR TITLE
remove library API support for namespace

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -67,7 +67,9 @@ const generateWithNormalizedOptions = ({
   className,
   modulePrefix,
   packageIdentifier = DEFAULT_PACKAGE_IDENTIFIER,
-  namespace,
+  // namespace - library API member removed since Windows platform
+  // is now removed (may be added back someday in the future)
+  // namespace,
   platforms = DEFAULT_PLATFORMS,
   tvosEnabled = false,
   githubAccount = DEFAULT_GITHUB_ACCOUNT,
@@ -164,7 +166,9 @@ const generateWithNormalizedOptions = ({
           name: className,
           moduleName,
           packageIdentifier,
-          namespace,
+          // namespace - library API member removed since Windows platform
+          // is now removed (may be added back someday in the future)
+          // namespace,
           platforms,
           tvosEnabled,
           githubAccount,

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -20,7 +20,9 @@ module.exports = (options) => {
 
   // OPTIONS NOT DOCUMENTED, not supported by CLI:
   const className = options.className;
-  const namespace = options.namespace;
+  // namespace - library API member removed since Windows platform
+  // is now removed (may be added back someday in the future)
+  // const namespace = options.namespace;
 
   return Object.assign(
     { name, prefix, modulePrefix },
@@ -31,8 +33,10 @@ module.exports = (options) => {
     className
       ? {}
       : { className: `${prefix}${pascalCase(name)}` },
-    namespace
-      ? {}
-      : { namespace: pascalCase(name).split(/(?=[A-Z])/).join('.') },
+    // namespace - library API member removed since Windows platform
+    // is now removed (may be added back someday in the future)
+    // namespace
+    //   ? {}
+    //   : { namespace: pascalCase(name).split(/(?=[A-Z])/).join('.') },
   );
 };

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -20,6 +20,7 @@ module.exports = (options) => {
 
   // [TBD] OPTION(S) NOT DOCUMENTED, not supported by CLI:
   const className = options.className;
+
   // namespace - library API member removed since Windows platform
   // is now removed (may be added back someday in the future)
   // const namespace = options.namespace;

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -18,7 +18,7 @@ module.exports = (options) => {
 
   const moduleName = options.moduleName;
 
-  // [TBD] OPTION(S) NOT DOCUMENTED, not supported by CLI:
+  // [TBD] option NOT DOCUMENTED & NOT SUPPORTED by CLI:
   const className = options.className;
 
   // namespace - library API member removed since Windows platform

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -18,7 +18,7 @@ module.exports = (options) => {
 
   const moduleName = options.moduleName;
 
-  // OPTIONS NOT DOCUMENTED, not supported by CLI:
+  // [TBD] OPTION(S) NOT DOCUMENTED, not supported by CLI:
   const className = options.className;
   // namespace - library API member removed since Windows platform
   // is now removed (may be added back someday in the future)

--- a/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -45,9 +45,9 @@ Array [
     "error": Array [
       "Error: ENOPERM not permitted
     at Object.ensureDir (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:9:27)
-    at ensureDir (.../lib/lib.js:155:15)
-    at generateLibraryModule (.../lib/lib.js:281:10)
-    at generateWithNormalizedOptions (.../lib/lib.js:298:10)
+    at ensureDir (.../lib/lib.js:157:15)
+    at generateLibraryModule (.../lib/lib.js:285:10)
+    at generateWithNormalizedOptions (.../lib/lib.js:302:10)
     at createLibraryModule (.../lib/cli-command.js:...
     at Object.func (.../tests/with-mocks/cli/command/func/with-logging/with-error/cli-command-with-logging-with-error.test.js:62:9)
     ",


### PR DESCRIPTION
followup to 0de40fa - remove Windows (C#) support (PR #264)

extra namespace parameter no longer needed was discovered through
mutation testing using Stryker Mutator (as reported in issue #274)

namespace parameter is commented out for now, at least

(with an error logging test snapshot updated and a couple of other cleanup changes)

removed from library API since Windows platform is no longer supported

Note that it should be possible to add Windows platform again with support for the namespace parameter at some point in the future.