### PR TITLE
fix --class-name & some other options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ Usage: create-react-native-module [options] <name>
 Options:
 
   -V, --version                             output the version number
-  --prefix <prefix>                         The prefix for the library module (Default: ``)
+  --prefix <prefix>                         The prefix of the native library module, ignored if --class-name is specified (Default: ``)
   --module-name <moduleName>                The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix <modulePrefix>            The module prefix for the library module, ignored if --module-name is specified (Default: `react-native`)
+  --class-name <className>                  The name of the native object to be exported by the JavaScript and by the native code. Default: (prefix)(name in PascalCase)
+  --module-prefix <modulePrefix>            The native module prefix for the library module package name, ignored if --module-name is specified (Default: `react-native`)
   --package-identifier <packageIdentifier>  [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
   --tvos-enabled                            Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
@@ -129,9 +130,10 @@ createLibraryModule({
 ```javascript
 {
   name: String, /* The name of the library (Default: Library) */
-  prefix: String, /* The prefix for the library (Default: ``) */
+  prefix: String, /* The prefix of the native library module, ignored if className is specified (Default: ``) */
   moduleName: String, /* The module library package name to be used in package.json. Default: react-native-(name in param-case) */
-  modulePrefix: String, /* The module prefix for the library, ignored if moduleName is specified (Default: react-native) */
+  className: String, /* The name of the native object to be exported by the JavaScript and by the native code. Default: (prefix)(name in PascalCase) */
+  modulePrefix: String, /* The native module prefix for the library module package name, ignored if moduleName is specified (Default: react-native) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
   packageIdentifier: String, /* [Android] The Java package identifier used by the Android module (Default: com.reactlibrary) */
   tvosEnabled: Boolean, /* Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled) */

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -72,14 +72,17 @@ ${postCreateInstructions(createOptions)}`);
   },
   options: [{
     command: '--prefix [prefix]',
-    description: 'The prefix for the library module',
+    description: 'The prefix of the native library module, ignored if --class-name is specified',
     default: '',
   }, {
     command: '--module-name [moduleName]',
     description: 'The module library package name to be used in package.json. Default: react-native-(name in param-case)',
   }, {
+    command: '--class-name [className]',
+    description: 'The name of the native object to be exported by the JavaScript and by the native code. Default: (prefix)(name in PascalCase)',
+  }, {
     command: '--module-prefix [modulePrefix]',
-    description: 'The module prefix for the library module, ignored if --module-name is specified',
+    description: 'The native module prefix for the library module package name, ignored if --module-name is specified',
     default: 'react-native',
   }, {
     command: '--package-identifier [packageIdentifier]',

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -18,7 +18,6 @@ module.exports = (options) => {
 
   const moduleName = options.moduleName;
 
-  // [TBD] option NOT DOCUMENTED & NOT SUPPORTED by CLI:
   const className = options.className;
 
   // namespace - library API member removed since Windows platform

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -7,9 +7,10 @@ creates a React Native library module for one or more platforms
 
 Options:
   -V, --version                                               output the version number
-  --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
+  --prefix [prefix]                                           The prefix of the native library module, ignored if --class-name is specified (default: \\"\\")
   --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
+  --class-name [className]                                    The name of the native object to be exported by the JavaScript and by the native code. Default: (prefix)(name in PascalCase)
+  --module-prefix [modulePrefix]                              The native module prefix for the library module package name, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -7,9 +7,10 @@ creates a React Native library module for one or more platforms
 
 Options:
   -V, --version                                               output the version number
-  --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
+  --prefix [prefix]                                           The prefix of the native library module, ignored if --class-name is specified (default: \\"\\")
   --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
+  --class-name [className]                                    The name of the native object to be exported by the JavaScript and by the native code. Default: (prefix)(name in PascalCase)
+  --module-prefix [modulePrefix]                              The native module prefix for the library module package name, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -9,16 +9,20 @@ Object {
     Object {
       "command": "--prefix [prefix]",
       "default": "",
-      "description": "The prefix for the library module",
+      "description": "The prefix of the native library module, ignored if --class-name is specified",
     },
     Object {
       "command": "--module-name [moduleName]",
       "description": "The module library package name to be used in package.json. Default: react-native-(name in param-case)",
     },
     Object {
+      "command": "--class-name [className]",
+      "description": "The name of the native object to be exported by the JavaScript and by the native code. Default: (prefix)(name in PascalCase)",
+    },
+    Object {
       "command": "--module-prefix [modulePrefix]",
       "default": "react-native",
-      "description": "The module prefix for the library module, ignored if --module-name is specified",
+      "description": "The native module prefix for the library module package name, ignored if --module-name is specified",
     },
     Object {
       "command": "--package-identifier [packageIdentifier]",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -31,7 +31,7 @@ Array [
     "option": Object {
       "args": Array [
         "--prefix [prefix]",
-        "The prefix for the library module",
+        "The prefix of the native library module, ignored if --class-name is specified",
         [Function],
         "",
       ],
@@ -50,8 +50,18 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--class-name [className]",
+        "The name of the native object to be exported by the JavaScript and by the native code. Default: (prefix)(name in PascalCase)",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--module-prefix [modulePrefix]",
-        "The module prefix for the library module, ignored if --module-name is specified",
+        "The native module prefix for the library module package name, ignored if --module-name is specified",
         [Function],
         "react-native",
       ],

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -29,7 +29,7 @@ Array [
     "option": Object {
       "args": Array [
         "--prefix [prefix]",
-        "The prefix for the library module",
+        "The prefix of the native library module, ignored if --class-name is specified",
         [Function],
         "",
       ],
@@ -48,8 +48,18 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--class-name [className]",
+        "The name of the native object to be exported by the JavaScript and by the native code. Default: (prefix)(name in PascalCase)",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--module-prefix [modulePrefix]",
-        "The module prefix for the library module, ignored if --module-name is specified",
+        "The native module prefix for the library module package name, ignored if --module-name is specified",
         [Function],
         "react-native",
       ],


### PR DESCRIPTION
__Updated:__

- export & document `--class-name` CLI option
- document className library API option
- update description of `prefix` option
- fix & update description of modulePrefix
- remove an "option NOT DOCUMENTED & NOT SUPPORTED" comment
- update test snapshots

Undocumented `className` option was discovered in `lib/normalized-options.js` during cleanup removal of obsolete `namespace` option in PR #276 (followup fix to PR #264 to remove Windows (C#) support)

__Testing:__

- [x] test with generated library module and with generated view module

P.S. Update needed to description of modulePrefix was discovered while working on the undocumented `className` option.