### PR TITLE
add PR merge action

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,0 +1,21 @@
+# original source:
+# https://github.com/marketplace/actions/pull-request-merge-command#installation
+name: 'Merge command'
+
+on: issue_comment
+
+jobs:
+  merge-command:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Merge command
+      uses: Goobles/gh-actions-merge-command@v1
+      with:
+        allow_ff: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/marketplace/actions/pull-request-merge-command

to pull & test from master before merging a PR

General motivation:

- ~~It is safest to pull and test from master before merging a PR~~ _GitHub should test this automatically, doesn't hurt to pull from master before merging though._
- There are PRs such as #277 which I may want to keep testing from the GitHub UI before I am finally ready to merge.

---

I did test this action on my own scratch project, hope it will work as expected on this one.