### PR TITLE
fix API & option descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ createLibraryModule({
 
 ```javascript
 {
-  name: String, /* The name of the library (Default: Library) */
+  name: String, /* The name of the library (mandatory) */
   prefix: String, /* The prefix for the library (Default: ``) */
   moduleName: String, /* The module library package name to be used in package.json. Default: react-native-(name in param-case) */
   modulePrefix: String, /* The module prefix for the library, ignored if moduleName is specified (Default: react-native) */

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Usage: create-react-native-module [options] <name>
 Options:
 
   -V, --version                             output the version number
-  --prefix <prefix>                         The prefix for the library module (Default: ``)
+  --prefix <prefix>                         The prefix of the library module object to be exported by both JavaScript and native code (Default: `')
   --module-name <moduleName>                The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix <modulePrefix>            The module prefix for the library module, ignored if --module-name is specified (Default: `react-native`)
+  --module-prefix <modulePrefix>            The prefix of the library module object, ignored if --module-name is specified (Default: `react-native`)
   --package-identifier <packageIdentifier>  [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
   --tvos-enabled                            Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
@@ -129,9 +129,9 @@ createLibraryModule({
 ```javascript
 {
   name: String, /* The name of the library (mandatory) */
-  prefix: String, /* The prefix for the library (Default: ``) */
+  prefix: String, /* The prefix of the library module object to be exported by both JavaScript and native code (Default: ``) */
   moduleName: String, /* The module library package name to be used in package.json. Default: react-native-(name in param-case) */
-  modulePrefix: String, /* The module prefix for the library, ignored if moduleName is specified (Default: react-native) */
+  modulePrefix: String, /* The prefix of the library module object, ignored if moduleName is specified (Default: `react-native`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
   packageIdentifier: String, /* [Android] The Java package identifier used by the Android module (Default: com.reactlibrary) */
   tvosEnabled: Boolean, /* Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled) */

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Usage: create-react-native-module [options] <name>
 Options:
 
   -V, --version                             output the version number
-  --prefix <prefix>                         The prefix of the library module object to be exported by both JavaScript and native code (Default: `')
+  --prefix <prefix>                         The prefix of the library module object to be exported by both JavaScript and native code (Default: ``)
   --module-name <moduleName>                The module library package name to be used in package.json. Default: react-native-(name in param-case)
   --module-prefix <modulePrefix>            The prefix of the library module object, ignored if --module-name is specified (Default: `react-native`)
   --package-identifier <packageIdentifier>  [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -72,14 +72,14 @@ ${postCreateInstructions(createOptions)}`);
   },
   options: [{
     command: '--prefix [prefix]',
-    description: 'The prefix for the library module',
+    description: 'The prefix of the library module object to be exported by both JavaScript and native code',
     default: '',
   }, {
     command: '--module-name [moduleName]',
     description: 'The module library package name to be used in package.json. Default: react-native-(name in param-case)',
   }, {
     command: '--module-prefix [modulePrefix]',
-    description: 'The module prefix for the library module, ignored if --module-name is specified',
+    description: 'The prefix of the library module object, ignored if --module-name is specified',
     default: 'react-native',
   }, {
     command: '--package-identifier [packageIdentifier]',

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -7,9 +7,9 @@ creates a React Native library module for one or more platforms
 
 Options:
   -V, --version                                               output the version number
-  --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
+  --prefix [prefix]                                           The prefix of the library module object to be exported by both JavaScript and native code (default: \\"\\")
   --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
+  --module-prefix [modulePrefix]                              The prefix of the library module object, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -7,9 +7,9 @@ creates a React Native library module for one or more platforms
 
 Options:
   -V, --version                                               output the version number
-  --prefix [prefix]                                           The prefix for the library module (default: \\"\\")
+  --prefix [prefix]                                           The prefix of the library module object to be exported by both JavaScript and native code (default: \\"\\")
   --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix [modulePrefix]                              The module prefix for the library module, ignored if --module-name is specified (default: \\"react-native\\")
+  --module-prefix [modulePrefix]                              The prefix of the library module object, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -9,7 +9,7 @@ Object {
     Object {
       "command": "--prefix [prefix]",
       "default": "",
-      "description": "The prefix for the library module",
+      "description": "The prefix of the library module object to be exported by both JavaScript and native code",
     },
     Object {
       "command": "--module-name [moduleName]",
@@ -18,7 +18,7 @@ Object {
     Object {
       "command": "--module-prefix [modulePrefix]",
       "default": "react-native",
-      "description": "The module prefix for the library module, ignored if --module-name is specified",
+      "description": "The prefix of the library module object, ignored if --module-name is specified",
     },
     Object {
       "command": "--package-identifier [packageIdentifier]",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -31,7 +31,7 @@ Array [
     "option": Object {
       "args": Array [
         "--prefix [prefix]",
-        "The prefix for the library module",
+        "The prefix of the library module object to be exported by both JavaScript and native code",
         [Function],
         "",
       ],
@@ -51,7 +51,7 @@ Array [
     "option": Object {
       "args": Array [
         "--module-prefix [modulePrefix]",
-        "The module prefix for the library module, ignored if --module-name is specified",
+        "The prefix of the library module object, ignored if --module-name is specified",
         [Function],
         "react-native",
       ],

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -29,7 +29,7 @@ Array [
     "option": Object {
       "args": Array [
         "--prefix [prefix]",
-        "The prefix for the library module",
+        "The prefix of the library module object to be exported by both JavaScript and native code",
         [Function],
         "",
       ],
@@ -49,7 +49,7 @@ Array [
     "option": Object {
       "args": Array [
         "--module-prefix [modulePrefix]",
-        "The module prefix for the library module, ignored if --module-name is specified",
+        "The prefix of the library module object, ignored if --module-name is specified",
         [Function],
         "react-native",
       ],


### PR DESCRIPTION
- fix description of the mandatory `name` parameter in the library API
- update `--prefix` & `--module-prefix` descriptions in `README.md`
- update `--prefix` & `--module-prefix` descriptions in `cli-command.js`
- update test snapshots

followup to reverted PR #278 (reverted in #299) which was in followup to PRs #276 & #264 (removing Windows C# platform support)

I think this series of updates and fixes shows the benefit of slower and more careful development.