### PR TITLE
quick fixes to handle CLI args errors

### DIFF
--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -41,6 +41,10 @@ module.exports = {
   description: 'creates a React Native library module for one or more platforms',
   usage: '[options] <name>',
   action: (args, options) => {
+    if (args.length > 1) {
+      throw new Error('too many arguments');
+    }
+
     const name = args[0];
 
     const beforeCreation = Date.now();

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -41,6 +41,10 @@ module.exports = {
   description: 'creates a React Native library module for one or more platforms',
   usage: '[options] <name>',
   action: (args, options) => {
+    if (!args || args.length < 1) {
+      throw new Error('missing lib module name');
+    }
+
     if (args.length > 1) {
       throw new Error('too many arguments');
     }

--- a/tests/with-injection/cli/command/action-error/cli-action-error-empty-args-missing-name.test.js
+++ b/tests/with-injection/cli/command/action-error/cli-action-error-empty-args-missing-name.test.js
@@ -1,0 +1,7 @@
+const action = require('../../../../../lib/cli-command.js').action;
+
+test('create lib module with empty args - missing name', () => {
+  const args = [];
+
+  expect(() => { action(args, {}); }).toThrow("Please write your library's name");
+});

--- a/tests/with-injection/cli/command/action-error/cli-action-error-empty-args-missing-name.test.js
+++ b/tests/with-injection/cli/command/action-error/cli-action-error-empty-args-missing-name.test.js
@@ -3,5 +3,5 @@ const action = require('../../../../../lib/cli-command.js').action;
 test('create lib module with empty args - missing name', () => {
   const args = [];
 
-  expect(() => { action(args, {}); }).toThrow("Please write your library's name");
+  expect(() => { action(args, {}); }).toThrow('missing lib module name');
 });

--- a/tests/with-injection/cli/command/action-error/cli-action-error-too-many-args.test.js
+++ b/tests/with-injection/cli/command/action-error/cli-action-error-too-many-args.test.js
@@ -3,8 +3,7 @@ const action = require('../../../../../lib/cli-command.js').action;
 test('create module with too many args', () => {
   const args = ['name1', 'name2'];
 
-  // fails at this point, generating module package with name1 only
-  // (issue 119 - extra arguments silently ignored)
-  // TODO: add expected error message
-  expect(() => { action(args, {}); }).toThrow();
+  // ref:
+  // https://github.com/brodybits/create-react-native-module/issues/119
+  expect(() => { action(args, {}); }).toThrow('too many arguments');
 });

--- a/tests/with-injection/cli/command/action-error/cli-action-error-too-many-args.test.js
+++ b/tests/with-injection/cli/command/action-error/cli-action-error-too-many-args.test.js
@@ -1,0 +1,10 @@
+const action = require('../../../../../lib/cli-command.js').action;
+
+test('create module with too many args', () => {
+  const args = ['name1', 'name2'];
+
+  // fails at this point, generating module package with name1 only
+  // (issue 119 - extra arguments silently ignored)
+  // TODO: add expected error message
+  expect(() => { action(args, {}); }).toThrow();
+});

--- a/tests/with-injection/cli/command/action-error/cli-action-error-undefined-args-missing-name.test.js
+++ b/tests/with-injection/cli/command/action-error/cli-action-error-undefined-args-missing-name.test.js
@@ -5,5 +5,5 @@ test('create lib module with undefined args - missing name', () => {
 
   // reproduces the following error ref:
   // https://github.com/brodybits/create-react-native-module/issues/305
-  expect(() => { action(args, {}); }).toThrow("Cannot read property '0' of undefined");
+  expect(() => { action(args, {}); }).toThrow("Cannot read property 'length' of undefined");
 });

--- a/tests/with-injection/cli/command/action-error/cli-action-error-undefined-args-missing-name.test.js
+++ b/tests/with-injection/cli/command/action-error/cli-action-error-undefined-args-missing-name.test.js
@@ -3,7 +3,7 @@ const action = require('../../../../../lib/cli-command.js').action;
 test('create lib module with undefined args - missing name', () => {
   const args = undefined;
 
-  // reproduces the following error ref:
+  // ref:
   // https://github.com/brodybits/create-react-native-module/issues/305
-  expect(() => { action(args, {}); }).toThrow("Cannot read property 'length' of undefined");
+  expect(() => { action(args, {}); }).toThrow('missing lib module name');
 });

--- a/tests/with-injection/cli/command/action-error/cli-action-error-undefined-args-missing-name.test.js
+++ b/tests/with-injection/cli/command/action-error/cli-action-error-undefined-args-missing-name.test.js
@@ -1,0 +1,9 @@
+const action = require('../../../../../lib/cli-command.js').action;
+
+test('create lib module with undefined args - missing name', () => {
+  const args = undefined;
+
+  // reproduces the following error ref:
+  // https://github.com/brodybits/create-react-native-module/issues/305
+  expect(() => { action(args, {}); }).toThrow("Cannot read property '0' of undefined");
+});


### PR DESCRIPTION
- throw explicit error in case of missing `args` or empty `args` array from `lib/cli-program.js` - resolves #305
- throw error in case of too many arguments in `args` array from `lib/cli-program.js` - resolves #119

with CLI lib tests in `tests/with-injection/cli/command/action-error`

---

P.S. This was tested from the command line with the following commands:

- `./bin/cli.js --view`
- `./bin/cli.js name1 name2`