### PR TITLE
add Stryker GitHub action

### DIFF
--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -1,0 +1,30 @@
+# based on GitHub template:
+name: Stryker CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - run: npm install
+
+    # ref:
+    # https://github.com/stryker-mutator/robobar-example/blob/master/.github/workflows/mutation-testing.yml
+    - name: Run Stryker, with API key
+      run: npm run stryker
+      env:
+        STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -14,7 +14,8 @@ module.exports = config => {
     reporters: [
       'html',
       'clear-text',
-      'progress'
+      'progress',
+      'dashboard'
     ],
     testRunner: 'jest',
     transpilers: [],


### PR DESCRIPTION
P.S. The prerequisite is to configure the Stryker dashboard API key ref:

- https://stryker-mutator.io/blog/2019-12-27/stryker-dashboard-host-your-mutation-testing-report
- https://github.com/stryker-mutator/stryker-handbook/blob/master/dashboard.md
- https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets