### PR TITLE
update create options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ Usage: create-react-native-module [options] <name>
 Options:
 
   -V, --version                             output the version number
+  --module-name <moduleName>                The module package name to be used in package.json. Default: react-native-(name in param-case)
+  --view                                    Generate the package as a very simple native view component
   --prefix <prefix>                         The prefix of the library module object to be exported by both JavaScript and native code (Default: ``)
-  --module-name <moduleName>                The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix <modulePrefix>            The prefix of the library module object, ignored if --module-name is specified (Default: `react-native`)
+  --module-prefix <modulePrefix>            The prefix of the generated module package name, ignored if --module-name is specified (Default: `react-native`)
   --package-identifier <packageIdentifier>  [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
   --tvos-enabled                            Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
@@ -101,7 +102,6 @@ Options:
   --author-name <authorName>                The author's name (Default: `Your Name`)
   --author-email <authorEmail>              The author's email (Default: `yourname@email.com`)
   --license <license>                       The license type (Default: `MIT`)
-  --view                                    Generate the module as a very simple native view component
   --use-apple-networking                    [iOS] Use `AFNetworking` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                        Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires both react-native-cli and yarn to be installed globally
   --example-file-linkage                    DEPRECATED: do `yarn add file:../` instead of `yarn add link:../` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js
@@ -128,9 +128,11 @@ createLibraryModule({
 ```javascript
 {
   name: String, /* The name of the library (mandatory) */
-  prefix: String, /* The prefix of the library module object to be exported by both JavaScript and native code (Default: ``) */
-  moduleName: String, /* The module library package name to be used in package.json. Default: react-native-(name in param-case) */
-  modulePrefix: String, /* The prefix of the library module object, ignored if moduleName is specified (Default: `react-native`) */
+  moduleName: String, /* The module package name to be used in package.json. Default: react-native-(name in param-case) */
+  view: Boolean, /* Generate the package as a very simple native view component (Default: false) */
+  className: String, /* The name of the object class to be exported by both JavaScript and native code, deprecated due to plans to rename this option (Default: ``) */
+  prefix: String, /* The prefix of the library module object to be exported by both JavaScript and native code, ignored if className is specified (Default: ``) */
+  modulePrefix: String, /* The prefix of the generated module package name, ignored if moduleName is specified (Default: `react-native`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
   packageIdentifier: String, /* [Android] The Java package identifier used by the Android module (Default: com.reactlibrary) */
   tvosEnabled: Boolean, /* Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled) */
@@ -139,7 +141,6 @@ createLibraryModule({
   authorEmail: String, /* The author's email (Default: `yourname@email.com`) */
   license: String, /* The license type of this library (Default: `MIT`) */
   useAppleNetworking: Boolean, /* [iOS] Use `AFNetworking` dependency as a sample in the podspec & use it from the iOS code (Default: false) */
-  view: Boolean, /* Generate the module as a very simple native view component (Default: false) */
   generateExample: Boolean, /* Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires both react-native-cli and yarn to be installed globally (Default: false) */
   exampleFileLinkage: Boolean, /* DEPRECATED: do `yarn add file:../` instead of `yarn add link:../` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js (Default: false) */
   exampleName: String, /* Name for the example project (Default: `example`) */

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -82,15 +82,18 @@ ${postCreateInstructions(createOptions)}`);
     });
   },
   options: [{
+    command: '--module-name [moduleName]',
+    description: 'The module package name to be used in package.json. Default: react-native-(name in param-case)',
+  }, {
+    command: '--view',
+    description: 'Generate the package as a very simple native view component',
+  }, {
     command: '--prefix [prefix]',
     description: 'The prefix of the library module object to be exported by both JavaScript and native code',
     default: '',
   }, {
-    command: '--module-name [moduleName]',
-    description: 'The module library package name to be used in package.json. Default: react-native-(name in param-case)',
-  }, {
     command: '--module-prefix [modulePrefix]',
-    description: 'The prefix of the library module object, ignored if --module-name is specified',
+    description: 'The prefix of the generated module package name, ignored if --module-name is specified',
     default: 'react-native',
   }, {
     command: '--package-identifier [packageIdentifier]',
@@ -119,9 +122,6 @@ ${postCreateInstructions(createOptions)}`);
     command: '--license [license]',
     description: 'The license type',
     default: 'MIT',
-  }, {
-    command: '--view',
-    description: 'Generate the module as a very simple native view component',
   }, {
     command: '--use-apple-networking',
     description: '[iOS] Use `AFNetworking` dependency as a sample in the podspec & use it from the iOS code',

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -7,9 +7,10 @@ creates a React Native library module for one or more platforms
 
 Options:
   -V, --version                                               output the version number
+  --module-name [moduleName]                                  The module package name to be used in package.json. Default: react-native-(name in param-case)
+  --view                                                      Generate the package as a very simple native view component
   --prefix [prefix]                                           The prefix of the library module object to be exported by both JavaScript and native code (default: \\"\\")
-  --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix [modulePrefix]                              The prefix of the library module object, ignored if --module-name is specified (default: \\"react-native\\")
+  --module-prefix [modulePrefix]                              The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
@@ -17,7 +18,6 @@ Options:
   --author-name [authorName]                                  The author's name (default: \\"Your Name\\")
   --author-email [authorEmail]                                The author's email (default: \\"yourname@email.com\\")
   --license [license]                                         The license type (default: \\"MIT\\")
-  --view                                                      Generate the module as a very simple native view component
   --use-apple-networking                                      [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                                          Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires both react-native-cli and yarn to be installed globally
   --example-file-linkage                                      DEPRECATED: do \`yarn add file:../\` instead of \`yarn add link:../\` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -7,9 +7,10 @@ creates a React Native library module for one or more platforms
 
 Options:
   -V, --version                                               output the version number
+  --module-name [moduleName]                                  The module package name to be used in package.json. Default: react-native-(name in param-case)
+  --view                                                      Generate the package as a very simple native view component
   --prefix [prefix]                                           The prefix of the library module object to be exported by both JavaScript and native code (default: \\"\\")
-  --module-name [moduleName]                                  The module library package name to be used in package.json. Default: react-native-(name in param-case)
-  --module-prefix [modulePrefix]                              The prefix of the library module object, ignored if --module-name is specified (default: \\"react-native\\")
+  --module-prefix [modulePrefix]                              The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
   --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
@@ -17,7 +18,6 @@ Options:
   --author-name [authorName]                                  The author's name (default: \\"Your Name\\")
   --author-email [authorEmail]                                The author's email (default: \\"yourname@email.com\\")
   --license [license]                                         The license type (default: \\"MIT\\")
-  --view                                                      Generate the module as a very simple native view component
   --use-apple-networking                                      [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
   --generate-example                                          Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires both react-native-cli and yarn to be installed globally
   --example-file-linkage                                      DEPRECATED: do \`yarn add file:../\` instead of \`yarn add link:../\` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -7,18 +7,22 @@ Object {
   "name": "create-library",
   "options": Array [
     Object {
+      "command": "--module-name [moduleName]",
+      "description": "The module package name to be used in package.json. Default: react-native-(name in param-case)",
+    },
+    Object {
+      "command": "--view",
+      "description": "Generate the package as a very simple native view component",
+    },
+    Object {
       "command": "--prefix [prefix]",
       "default": "",
       "description": "The prefix of the library module object to be exported by both JavaScript and native code",
     },
     Object {
-      "command": "--module-name [moduleName]",
-      "description": "The module library package name to be used in package.json. Default: react-native-(name in param-case)",
-    },
-    Object {
       "command": "--module-prefix [modulePrefix]",
       "default": "react-native",
-      "description": "The prefix of the library module object, ignored if --module-name is specified",
+      "description": "The prefix of the generated module package name, ignored if --module-name is specified",
     },
     Object {
       "command": "--package-identifier [packageIdentifier]",
@@ -53,10 +57,6 @@ Object {
       "command": "--license [license]",
       "default": "MIT",
       "description": "The license type",
-    },
-    Object {
-      "command": "--view",
-      "description": "Generate the module as a very simple native view component",
     },
     Object {
       "command": "--use-apple-networking",

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -30,6 +30,26 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--module-name [moduleName]",
+        "The module package name to be used in package.json. Default: react-native-(name in param-case)",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--view",
+        "Generate the package as a very simple native view component",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--prefix [prefix]",
         "The prefix of the library module object to be exported by both JavaScript and native code",
         [Function],
@@ -40,18 +60,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--module-name [moduleName]",
-        "The module library package name to be used in package.json. Default: react-native-(name in param-case)",
-        [Function],
-        undefined,
-      ],
-    },
-  },
-  Object {
-    "option": Object {
-      "args": Array [
         "--module-prefix [modulePrefix]",
-        "The prefix of the library module object, ignored if --module-name is specified",
+        "The prefix of the generated module package name, ignored if --module-name is specified",
         [Function],
         "react-native",
       ],
@@ -124,16 +134,6 @@ Array [
         "The license type",
         [Function],
         "MIT",
-      ],
-    },
-  },
-  Object {
-    "option": Object {
-      "args": Array [
-        "--view",
-        "Generate the module as a very simple native view component",
-        [Function],
-        undefined,
       ],
     },
   },

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -28,6 +28,26 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--module-name [moduleName]",
+        "The module package name to be used in package.json. Default: react-native-(name in param-case)",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
+        "--view",
+        "Generate the package as a very simple native view component",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--prefix [prefix]",
         "The prefix of the library module object to be exported by both JavaScript and native code",
         [Function],
@@ -38,18 +58,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--module-name [moduleName]",
-        "The module library package name to be used in package.json. Default: react-native-(name in param-case)",
-        [Function],
-        undefined,
-      ],
-    },
-  },
-  Object {
-    "option": Object {
-      "args": Array [
         "--module-prefix [modulePrefix]",
-        "The prefix of the library module object, ignored if --module-name is specified",
+        "The prefix of the generated module package name, ignored if --module-name is specified",
         [Function],
         "react-native",
       ],
@@ -122,16 +132,6 @@ Array [
         "The license type",
         [Function],
         "MIT",
-      ],
-    },
-  },
-  Object {
-    "option": Object {
-      "args": Array [
-        "--view",
-        "Generate the module as a very simple native view component",
-        [Function],
-        undefined,
       ],
     },
   },


### PR DESCRIPTION
- move --module-name & --view options to near the beginning in CLI & documentation
- update help text & documentation of --module-name, --view, & --module-prefix options
- document className option in library API
  (which is deprecated due to plans to rename the option)
- update documentation of prefix option in library API only