### PR TITLE
major: remove generated .gitattributes artifact

### DIFF
--- a/templates/general.js
+++ b/templates/general.js
@@ -153,14 +153,5 @@ buck-out/
     }
 
     return content;
-  },
-}, {
-  name: () => '.gitattributes',
-  content: ({ platforms }) => {
-    if (platforms.indexOf('ios') >= 0) {
-      return '*.pbxproj -text\n';
-    }
-
-    return '';
   }
 }];

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -3,11 +3,6 @@
 exports[`CLI creates correct view module package artifacts on file system using \`--view\` option (and no other options) 1`] = `
 Array [
   Object {
-    "name": "react-native-integration-view-test-package/.gitattributes",
-    "theContent": "*.pbxproj -text
-",
-  },
-  Object {
     "name": "react-native-integration-view-test-package/.gitignore",
     "theContent": "# OSX
 #

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -3,11 +3,6 @@
 exports[`CLI creates correct package artifacts on file system, with no options 1`] = `
 Array [
   Object {
-    "name": "react-native-integration-test-package/.gitattributes",
-    "theContent": "*.pbxproj -text
-",
-  },
-  Object {
     "name": "react-native-integration-test-package/.gitignore",
     "theContent": "# OSX
 #

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -159,13 +157,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -16,8 +16,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -163,13 +161,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -16,8 +16,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -163,13 +161,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -127,12 +125,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
@@ -14,8 +14,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/ios/
 ",
   "* ensureDir dir: react-native-alice-bobbi/ios/
@@ -135,13 +133,6 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -159,13 +157,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/bogus-name/__snapshots__/bogus-platforms-name.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* outputFile name: react-native-alice-bobbi/README.md
 content:
 --------
@@ -103,12 +101,6 @@ content:
 node_modules/
 npm-debug.log
 yarn-error.log
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-array/__snapshots__/bogus-platforms-empty-array.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* outputFile name: react-native-alice-bobbi/README.md
 content:
 --------
@@ -103,12 +101,6 @@ content:
 node_modules/
 npm-debug.log
 yarn-error.log
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
+++ b/tests/with-injection/create/with-defaults/bogus-platforms/empty-string/__snapshots__/bogus-platforms-empty-string.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* outputFile name: react-native-alice-bobbi/README.md
 content:
 --------
@@ -103,12 +101,6 @@ content:
 node_modules/
 npm-debug.log
 yarn-error.log
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
+++ b/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
@@ -16,8 +16,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -131,12 +129,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -16,8 +16,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -163,13 +161,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -16,8 +16,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -163,13 +161,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -16,8 +16,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -163,13 +161,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -16,8 +16,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -163,13 +161,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -159,13 +157,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -127,12 +125,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -14,8 +14,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/ios/
 ",
   "* ensureDir dir: react-native-alice-bobbi/ios/
@@ -135,13 +133,6 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -159,13 +157,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/
-",
   "* ensureDir dir: react-native-alice-bobbi/android/
 ",
   "* ensureDir dir: react-native-alice-bobbi/android/src/main/
@@ -159,13 +157,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: react-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: custom-native-alice-bobbi/
 ",
-  "* ensureDir dir: custom-native-alice-bobbi/
-",
   "* ensureDir dir: custom-native-alice-bobbi/android/
 ",
   "* ensureDir dir: custom-native-alice-bobbi/android/src/main/
@@ -159,13 +157,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: custom-native-alice-bobbi/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -12,8 +12,6 @@ Array [
 ",
   "* ensureDir dir: custom-native-module/
 ",
-  "* ensureDir dir: custom-native-module/
-",
   "* ensureDir dir: custom-native-module/android/
 ",
   "* ensureDir dir: custom-native-module/android/src/main/
@@ -159,13 +157,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-
-<<<<<<<< ======== >>>>>>>>
-",
-  "* outputFile name: custom-native-module/.gitattributes
-content:
---------
-*.pbxproj -text
 
 <<<<<<<< ======== >>>>>>>>
 ",

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -51,9 +51,6 @@ Android packageIdentifier: com.reactlibrary
     "ensureDir": "react-native-alice-bobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
-  },
-  Object {
     "outputFileName": "react-native-alice-bobbi/README.md",
     "theContent": "# react-native-alice-bobbi
 
@@ -136,10 +133,6 @@ node_modules/
 npm-debug.log
 yarn-error.log
 ",
-  },
-  Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
-    "theContent": "",
   },
   Object {
     "log": Array [

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -51,9 +51,6 @@ Android packageIdentifier: com.reactlibrary
     "ensureDir": "react-native-alice-bobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
-  },
-  Object {
     "outputFileName": "react-native-alice-bobbi/README.md",
     "theContent": "# react-native-alice-bobbi
 
@@ -136,10 +133,6 @@ node_modules/
 npm-debug.log
 yarn-error.log
 ",
-  },
-  Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
-    "theContent": "",
   },
   Object {
     "log": Array [

--- a/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -18,9 +18,6 @@ Array [
     "ensureDir": "react-native-alice-bobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
-  },
-  Object {
     "ensureDir": "react-native-alice-bobbi/android/",
   },
   Object {
@@ -168,11 +165,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-",
-  },
-  Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
-    "theContent": "*.pbxproj -text
 ",
   },
   Object {

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -222,9 +222,6 @@ Array [
     "ensureDir": "react-native-test-package/",
   },
   Object {
-    "ensureDir": "react-native-test-package/",
-  },
-  Object {
     "ensureDir": "react-native-test-package/android/",
   },
   Object {
@@ -336,10 +333,6 @@ buck-out/
 \\\\.buckd/
 *.keystore
 ",
-  },
-  Object {
-    "outputFileName": "react-native-test-package/.gitattributes",
-    "theContent": "",
   },
   Object {
     "outputFileName": "react-native-test-package/android/build.gradle",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -88,9 +88,6 @@ Android packageIdentifier: com.reactlibrary
     "ensureDir": "react-native-alice-bobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
-  },
-  Object {
     "ensureDir": "react-native-alice-bobbi/android/",
   },
   Object {
@@ -238,11 +235,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-",
-  },
-  Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
-    "theContent": "*.pbxproj -text
 ",
   },
   Object {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -88,9 +88,6 @@ Android packageIdentifier: com.reactlibrary
     "ensureDir": "react-native-alice-bobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
-  },
-  Object {
     "ensureDir": "react-native-alice-bobbi/android/",
   },
   Object {
@@ -238,11 +235,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-",
-  },
-  Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
-    "theContent": "*.pbxproj -text
 ",
   },
   Object {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -88,9 +88,6 @@ Android packageIdentifier: com.reactlibrary
     "ensureDir": "react-native-alice-bobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
-  },
-  Object {
     "ensureDir": "react-native-alice-bobbi/android/",
   },
   Object {
@@ -238,11 +235,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-",
-  },
-  Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
-    "theContent": "*.pbxproj -text
 ",
   },
   Object {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -82,9 +82,6 @@ Android packageIdentifier: com.alicebits
     "ensureDir": "react-native-alice-bobbi/",
   },
   Object {
-    "ensureDir": "react-native-alice-bobbi/",
-  },
-  Object {
     "ensureDir": "react-native-alice-bobbi/android/",
   },
   Object {
@@ -232,11 +229,6 @@ local.properties
 buck-out/
 \\\\.buckd/
 *.keystore
-",
-  },
-  Object {
-    "outputFileName": "react-native-alice-bobbi/.gitattributes",
-    "theContent": "*.pbxproj -text
 ",
   },
   Object {


### PR DESCRIPTION
which I think is not really needed

I think this should be considered a "major", potentially breaking change for a new 0.x release.