### PR TITLE
cleanup example template render arguments

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -218,7 +218,6 @@ Android packageIdentifier: ${packageIdentifier}
             name: className,
             moduleName,
             view,
-            useAppleNetworking,
             exampleFileLinkage,
             exampleName,
             writeExamplePodfile,


### PR DESCRIPTION
remove useAppleNetworking not needed from internal function call

Keeping as draft for now. I would like to use this as an example to help get Stryker Mutator updated to detect this kind of argument not needed.