### PR TITLE
cleanup general template arguments

### DIFF
--- a/templates/general.js
+++ b/templates/general.js
@@ -21,7 +21,7 @@ ${name};
 `,
 }, {
   name: () => 'package.json',
-  content: ({ moduleName, platforms, githubAccount, authorName, authorEmail, license }) => {
+  content: ({ moduleName, githubAccount, authorName, authorEmail, license }) => {
     const peerDependencies =
       `{
     "react": "^16.8.1",


### PR DESCRIPTION
remove `platforms` argument no longer needed since dropping Windows (.NET) support in: 0de40fa1baba0909089b12d1b62e45777bf8bcc9

(this should have been done as part of PR #264)

I would like to get Stryker Mutator updated to detect this kind of possible cleanup, keeping as draft for now.