### PR TITLE
cleanup example template metro config arguments

### DIFF
--- a/templates/example.js
+++ b/templates/example.js
@@ -119,7 +119,7 @@ module.exports = [{
   // metro.config.js workarounds needed in case of `exampleFileLinkage: false`:
   name: ({ exampleName, exampleFileLinkage }) =>
     exampleFileLinkage ? undefined : `${exampleName}/metro.config.js`,
-  content: ({ moduleName, exampleName }) => `// metro.config.js
+  content: () => `// metro.config.js
 //
 // with multiple workarounds for this issue with symlinks:
 // https://github.com/facebook/metro/issues/1


### PR DESCRIPTION
remove arguments not needed

very similar to PR #329

I would like to get Stryker Mutator updated to detect this kind of possible cleanup, keeping as draft for now.