### PR TITLE
major: object class name updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ createLibraryModule({
   name: String, /* The name of the library (mandatory) */
   moduleName: String, /* The module package name to be used in package.json. Default: react-native-(name in param-case) */
   view: Boolean, /* Generate the package as a very simple native view component (Default: false) */
-  className: String, /* The name of the object class to be exported by both JavaScript and native code, deprecated due to plans to rename this option. Default: (name in PascalCase) */
+  objectClassName: String, /* The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase) */
   prefix: String, /* The prefix of the library module object to be exported by both JavaScript and native code, ignored if className is specified (Default: ``) */
   modulePrefix: String, /* The prefix of the generated module package name, ignored if moduleName is specified (Default: `react-native`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Options:
   --module-name <moduleName>                The module package name to be used in package.json. Default: react-native-(name in param-case)
   --view                                    Generate the package as a very simple native view component
   --object-class-name                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
-  --prefix <prefix>                         The prefix of the library module object to be exported by both JavaScript and native code (Default: ``)
+  --prefix <prefix>                         DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (Default: ``)
   --module-prefix <modulePrefix>            The prefix of the generated module package name, ignored if --module-name is specified (Default: `react-native`)
   --package-identifier <packageIdentifier>  [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
@@ -132,7 +132,7 @@ createLibraryModule({
   moduleName: String, /* The module package name to be used in package.json. Default: react-native-(name in param-case) */
   view: Boolean, /* Generate the package as a very simple native view component (Default: false) */
   objectClassName: String, /* The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase) */
-  prefix: String, /* The prefix of the library module object to be exported by both JavaScript and native code, ignored if className is specified (Default: ``) */
+  prefix: String, /* DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if objectClassName is specified (Default: ``) */
   modulePrefix: String, /* The prefix of the generated module package name, ignored if moduleName is specified (Default: `react-native`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
   packageIdentifier: String, /* [Android] The Java package identifier used by the Android module (Default: com.reactlibrary) */

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Options:
   -V, --version                             output the version number
   --module-name <moduleName>                The module package name to be used in package.json. Default: react-native-(name in param-case)
   --view                                    Generate the package as a very simple native view component
+  --object-class-name                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
   --prefix <prefix>                         The prefix of the library module object to be exported by both JavaScript and native code (Default: ``)
   --module-prefix <modulePrefix>            The prefix of the generated module package name, ignored if --module-name is specified (Default: `react-native`)
   --package-identifier <packageIdentifier>  [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ createLibraryModule({
   name: String, /* The name of the library (mandatory) */
   moduleName: String, /* The module package name to be used in package.json. Default: react-native-(name in param-case) */
   view: Boolean, /* Generate the package as a very simple native view component (Default: false) */
-  className: String, /* The name of the object class to be exported by both JavaScript and native code, deprecated due to plans to rename this option (Default: ``) */
+  className: String, /* The name of the object class to be exported by both JavaScript and native code, deprecated due to plans to rename this option. Default: (name in PascalCase) */
   prefix: String, /* The prefix of the library module object to be exported by both JavaScript and native code, ignored if className is specified (Default: ``) */
   modulePrefix: String, /* The prefix of the generated module package name, ignored if moduleName is specified (Default: `react-native`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -92,7 +92,7 @@ ${postCreateInstructions(createOptions)}`);
     description: 'The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)',
   }, {
     command: '--prefix [prefix]',
-    description: 'The prefix of the library module object to be exported by both JavaScript and native code',
+    description: 'DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified',
     default: '',
   }, {
     command: '--module-prefix [modulePrefix]',

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -88,6 +88,9 @@ ${postCreateInstructions(createOptions)}`);
     command: '--view',
     description: 'Generate the package as a very simple native view component',
   }, {
+    command: '--object-class-name [objectClassName]',
+    description: 'The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)',
+  }, {
     command: '--prefix [prefix]',
     description: 'The prefix of the library module object to be exported by both JavaScript and native code',
     default: '',

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -62,7 +62,7 @@ const npmAddScriptSync = (packageJsonPath, script, fs) => {
 
 const generateWithNormalizedOptions = ({
   name,
-  prefix,
+  prefix, // (only needed for logging purposes in this function)
   moduleName,
   objectClassName,
   modulePrefix,

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -64,7 +64,7 @@ const generateWithNormalizedOptions = ({
   name,
   prefix,
   moduleName,
-  className,
+  objectClassName,
   modulePrefix,
   packageIdentifier = DEFAULT_PACKAGE_IDENTIFIER,
   // namespace - library API member removed since Windows platform
@@ -104,7 +104,7 @@ const generateWithNormalizedOptions = ({
       (full package name): ${moduleName}
                   is view: ${view}
  object class name prefix: ${prefix}
-        object class name: ${className}
+        object class name: ${objectClassName}
      library modulePrefix: ${modulePrefix}
 Android packageIdentifier: ${packageIdentifier}
                 platforms: ${platforms}
@@ -167,8 +167,9 @@ Android packageIdentifier: ${packageIdentifier}
         return true;
       }).map((template) => {
         const templateArgs = {
-          name: className,
+          name: objectClassName,
           moduleName,
+          objectClassName,
           packageIdentifier,
           // namespace - library API member removed since Windows platform
           // is now removed (may be added back someday in the future)
@@ -212,8 +213,9 @@ Android packageIdentifier: ${packageIdentifier}
         .then(() => {
           // Render the example template
           const templateArgs = {
-            name: className,
+            name: objectClassName,
             moduleName,
+            objectClassName,
             view,
             useAppleNetworking,
             exampleFileLinkage,

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -18,7 +18,6 @@ module.exports = (options) => {
 
   const moduleName = options.moduleName;
 
-  // [TBD] NOT SUPPORTED by CLI:
   const { objectClassName } = options;
 
   // namespace - library API member removed since Windows platform

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -18,8 +18,8 @@ module.exports = (options) => {
 
   const moduleName = options.moduleName;
 
-  // [TBD] option NOT DOCUMENTED & NOT SUPPORTED by CLI:
-  const className = options.className;
+  // [TBD] NOT SUPPORTED by CLI:
+  const { objectClassName } = options;
 
   // namespace - library API member removed since Windows platform
   // is now removed (may be added back someday in the future)
@@ -31,9 +31,9 @@ module.exports = (options) => {
     moduleName
       ? {}
       : { moduleName: `${modulePrefix}-${paramCase(name)}` },
-    className
+    objectClassName
       ? {}
-      : { className: `${prefix}${pascalCase(name)}` },
+      : { objectClassName: `${prefix}${pascalCase(name)}` },
     // namespace - library API member removed since Windows platform
     // is now removed (may be added back someday in the future)
     // namespace

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -6,7 +6,7 @@ const { pascalCase } = require('pascal-case');
 const DEFAULT_MODULE_PREFIX = 'react-native';
 
 module.exports = (options) => {
-  const name = options.name;
+  const { name, moduleName, objectClassName } = options;
 
   const prefix = options.prefix || '';
 
@@ -15,10 +15,6 @@ module.exports = (options) => {
   if (typeof name !== 'string') {
     throw new TypeError("Please write your library's name");
   }
-
-  const moduleName = options.moduleName;
-
-  const { objectClassName } = options;
 
   // namespace - library API member removed since Windows platform
   // is now removed (may be added back someday in the future)

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -9,7 +9,8 @@ Options:
   -V, --version                                               output the version number
   --module-name [moduleName]                                  The module package name to be used in package.json. Default: react-native-(name in param-case)
   --view                                                      Generate the package as a very simple native view component
-  --prefix [prefix]                                           The prefix of the library module object to be exported by both JavaScript and native code (default: \\"\\")
+  --object-class-name [objectClassName]                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
+  --prefix [prefix]                                           DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (default: \\"\\")
   --module-prefix [modulePrefix]                              The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -9,7 +9,8 @@ Options:
   -V, --version                                               output the version number
   --module-name [moduleName]                                  The module package name to be used in package.json. Default: react-native-(name in param-case)
   --view                                                      Generate the package as a very simple native view component
-  --prefix [prefix]                                           The prefix of the library module object to be exported by both JavaScript and native code (default: \\"\\")
+  --object-class-name [objectClassName]                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
+  --prefix [prefix]                                           DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (default: \\"\\")
   --module-prefix [modulePrefix]                              The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -15,9 +15,13 @@ Object {
       "description": "Generate the package as a very simple native view component",
     },
     Object {
+      "command": "--object-class-name [objectClassName]",
+      "description": "The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)",
+    },
+    Object {
       "command": "--prefix [prefix]",
       "default": "",
-      "description": "The prefix of the library module object to be exported by both JavaScript and native code",
+      "description": "DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified",
     },
     Object {
       "command": "--module-prefix [modulePrefix]",

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -32,9 +32,9 @@ Array [
 ",
   "* ensureDir dir: react-native-alice-bobbi/ios/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: react-native-alice-bobbi/ios/SuperAwesomeModule.xcworkspace/
 ",
-  "* ensureDir dir: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: react-native-alice-bobbi/ios/SuperAwesomeModule.xcodeproj/
 ",
   "* outputFile name: react-native-alice-bobbi/README.md
 content:
@@ -51,10 +51,10 @@ content:
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'react-native-alice-bobbi';
+import SuperAwesomeModule from 'react-native-alice-bobbi';
 
 // TODO: What to do with the module?
-AliceBobbi;
+SuperAwesomeModule;
 \`\`\`
 
 <<<<<<<< ======== >>>>>>>>
@@ -110,9 +110,9 @@ content:
 --------
 import { NativeModules } from 'react-native';
 
-const { AliceBobbi } = NativeModules;
+const { SuperAwesomeModule } = NativeModules;
 
-export default AliceBobbi;
+export default SuperAwesomeModule;
 
 <<<<<<<< ======== >>>>>>>>
 ",
@@ -329,7 +329,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/SuperAwesomeModuleModule.java
 content:
 --------
 package com.reactlibrary;
@@ -339,18 +339,18 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
 
-public class AliceBobbiModule extends ReactContextBaseJavaModule {
+public class SuperAwesomeModuleModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
 
-    public AliceBobbiModule(ReactApplicationContext reactContext) {
+    public SuperAwesomeModuleModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
     }
 
     @Override
     public String getName() {
-        return \\"AliceBobbi\\";
+        return \\"SuperAwesomeModule\\";
     }
 
     @ReactMethod
@@ -362,7 +362,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: react-native-alice-bobbi/android/src/main/java/com/reactlibrary/SuperAwesomeModulePackage.java
 content:
 --------
 package com.reactlibrary;
@@ -377,10 +377,10 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.bridge.JavaScriptModule;
 
-public class AliceBobbiPackage implements ReactPackage {
+public class SuperAwesomeModulePackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Arrays.<NativeModule>asList(new AliceBobbiModule(reactContext));
+        return Arrays.<NativeModule>asList(new SuperAwesomeModuleModule(reactContext));
     }
 
     @Override
@@ -445,25 +445,25 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.h
+  "* outputFile name: react-native-alice-bobbi/ios/SuperAwesomeModule.h
 content:
 --------
 #import <React/RCTBridgeModule.h>
 
-@interface AliceBobbi : NSObject <RCTBridgeModule>
+@interface SuperAwesomeModule : NSObject <RCTBridgeModule>
 
 @end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.m
+  "* outputFile name: react-native-alice-bobbi/ios/SuperAwesomeModule.m
 content:
 --------
-#import \\"AliceBobbi.h\\"
+#import \\"SuperAwesomeModule.h\\"
 
 #import <AFNetworking/AFNetworking.h>
 
-@implementation AliceBobbi
+@implementation SuperAwesomeModule
 
 RCT_EXPORT_MODULE()
 
@@ -482,20 +482,20 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: react-native-alice-bobbi/ios/SuperAwesomeModule.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <Workspace
    version = \\"1.0\\">
    <FileRef
-      location = \\"group:AliceBobbi.xcodeproj\\">
+      location = \\"group:SuperAwesomeModule.xcodeproj\\">
    </FileRef>
 </Workspace>
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: react-native-alice-bobbi/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: react-native-alice-bobbi/ios/SuperAwesomeModule.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!
@@ -507,7 +507,7 @@ content:
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B3E7B58A1CC2AC0600A0062D /* AliceBobbi.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */; };
+		B3E7B58A1CC2AC0600A0062D /* SuperAwesomeModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* SuperAwesomeModule.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -523,9 +523,9 @@ content:
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		134814201AA4EA6300B7C361 /* libAliceBobbi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAliceBobbi.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		B3E7B5881CC2AC0600A0062D /* AliceBobbi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AliceBobbi.h; sourceTree = \\"<group>\\"; };
-		B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AliceBobbi.m; sourceTree = \\"<group>\\"; };
+		134814201AA4EA6300B7C361 /* libSuperAwesomeModule.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSuperAwesomeModule.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E7B5881CC2AC0600A0062D /* SuperAwesomeModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuperAwesomeModule.h; sourceTree = \\"<group>\\"; };
+		B3E7B5891CC2AC0600A0062D /* SuperAwesomeModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SuperAwesomeModule.m; sourceTree = \\"<group>\\"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -542,7 +542,7 @@ content:
 		134814211AA4EA7D00B7C361 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				134814201AA4EA6300B7C361 /* libAliceBobbi.a */,
+				134814201AA4EA6300B7C361 /* libSuperAwesomeModule.a */,
 			);
 			name = Products;
 			sourceTree = \\"<group>\\";
@@ -550,8 +550,8 @@ content:
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				B3E7B5881CC2AC0600A0062D /* AliceBobbi.h */,
-				B3E7B5891CC2AC0600A0062D /* AliceBobbi.m */,
+				B3E7B5881CC2AC0600A0062D /* SuperAwesomeModule.h */,
+				B3E7B5891CC2AC0600A0062D /* SuperAwesomeModule.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = \\"<group>\\";
@@ -559,9 +559,9 @@ content:
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		58B511DA1A9E6C8500147676 /* AliceBobbi */ = {
+		58B511DA1A9E6C8500147676 /* SuperAwesomeModule */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"AliceBobbi\\" */;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"SuperAwesomeModule\\" */;
 			buildPhases = (
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
@@ -571,9 +571,9 @@ content:
 			);
 			dependencies = (
 			);
-			name = AliceBobbi;
+			name = SuperAwesomeModule;
 			productName = RCTDataManager;
-			productReference = 134814201AA4EA6300B7C361 /* libAliceBobbi.a */;
+			productReference = 134814201AA4EA6300B7C361 /* libSuperAwesomeModule.a */;
 			productType = \\"com.apple.product-type.library.static\\";
 		};
 /* End PBXNativeTarget section */
@@ -590,7 +590,7 @@ content:
 					};
 				};
 			};
-			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"AliceBobbi\\" */;
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"SuperAwesomeModule\\" */;
 			compatibilityVersion = \\"Xcode 3.2\\";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -602,7 +602,7 @@ content:
 			projectDirPath = \\"\\";
 			projectRoot = \\"\\";
 			targets = (
-				58B511DA1A9E6C8500147676 /* AliceBobbi */,
+				58B511DA1A9E6C8500147676 /* SuperAwesomeModule */,
 			);
 		};
 /* End PBXProject section */
@@ -612,7 +612,7 @@ content:
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3E7B58A1CC2AC0600A0062D /* AliceBobbi.m in Sources */,
+				B3E7B58A1CC2AC0600A0062D /* SuperAwesomeModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -723,7 +723,7 @@ content:
 				);
 				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
 				OTHER_LDFLAGS = \\"-ObjC\\";
-				PRODUCT_NAME = AliceBobbi;
+				PRODUCT_NAME = SuperAwesomeModule;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -739,7 +739,7 @@ content:
 				);
 				LIBRARY_SEARCH_PATHS = \\"$(inherited)\\";
 				OTHER_LDFLAGS = \\"-ObjC\\";
-				PRODUCT_NAME = AliceBobbi;
+				PRODUCT_NAME = SuperAwesomeModule;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -747,7 +747,7 @@ content:
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"AliceBobbi\\" */ = {
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject \\"SuperAwesomeModule\\" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				58B511ED1A9E6C8500147676 /* Debug */,
@@ -756,7 +756,7 @@ content:
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"AliceBobbi\\" */ = {
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget \\"SuperAwesomeModule\\" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				58B511F01A9E6C8500147676 /* Debug */,
@@ -949,7 +949,7 @@ content:
 
 import React, { Component } from 'react';
 import { Platform, StyleSheet, Text, View } from 'react-native';
-import AliceBobbi from 'react-native-alice-bobbi';
+import SuperAwesomeModule from 'react-native-alice-bobbi';
 
 export default class App extends Component<{}> {
   state = {
@@ -957,7 +957,7 @@ export default class App extends Component<{}> {
     message: '--'
   };
   componentDidMount() {
-    AliceBobbi.sampleMethod('Testing', 123, (message) => {
+    SuperAwesomeModule.sampleMethod('Testing', 123, (message) => {
       this.setState({
         status: 'native callback received',
         message
@@ -967,7 +967,7 @@ export default class App extends Component<{}> {
   render() {
     return (
       <View style={styles.container}>
-        <Text style={styles.welcome}>☆AliceBobbi example☆</Text>
+        <Text style={styles.welcome}>☆SuperAwesomeModule example☆</Text>
         <Text style={styles.instructions}>STATUS: {this.state.status}</Text>
         <Text style={styles.welcome}>☆NATIVE CALLBACK MESSAGE☆</Text>
         <Text style={styles.instructions}>{this.state.message}</Text>

--- a/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
+++ b/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
@@ -9,6 +9,7 @@ test('create alice-bobbi module with example, with config options including `exa
 
   const options = {
     name: 'alice-bobbi',
+    className: 'SuperAwesomeModule',
     tvosEnabled: true,
     githubAccount: 'alicebits',
     authorName: 'Alice',

--- a/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
+++ b/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
@@ -9,7 +9,7 @@ test('create alice-bobbi module with example, with config options including `exa
 
   const options = {
     name: 'alice-bobbi',
-    className: 'SuperAwesomeModule',
+    objectClassName: 'SuperAwesomeModule',
     tvosEnabled: true,
     githubAccount: 'alicebits',
     authorName: 'Alice',

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -50,8 +50,18 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--object-class-name [objectClassName]",
+        "The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--prefix [prefix]",
-        "The prefix of the library module object to be exported by both JavaScript and native code",
+        "DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified",
         [Function],
         "",
       ],

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -48,8 +48,18 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--object-class-name [objectClassName]",
+        "The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--prefix [prefix]",
-        "The prefix of the library module object to be exported by both JavaScript and native code",
+        "DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified",
         [Function],
         "",
       ],


### PR DESCRIPTION
- update a test to test with object class name library API option ref: issue #336
- rename `className` to `objectClassName` in library API & update test case - BREAKING CHANGE
- add `--object-class-name` CLI option for `objectClassName`
- deprecate `prefix` option in CLI help test & documentation, which could be problematic due to issue #337
- documentation updates
- update affected test snapshots

intended for upcoming 0.x release

TODO items __- done__:

- [x] test use of the new CLI option with a generated example on Android & iOS
- [x] ~~cleanup: remove a now outdated comment about `objectClassName` & CLI in `lib/normalized-options.js`~~
- [x] ~~cleanup: combine destructuring of `name` & `objectClassName` options in `lib/normalized-options.js`~~
- [x] ~~add comment to `lib/lib.js` that `prefix` option is only needed for console log purposes in that module~~