### PR TITLE
cleanup object class name references

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -168,7 +168,6 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
         return true;
       }).map((template) => {
         const templateArgs = {
-          name: objectClassName,
           moduleName,
           objectClassName,
           packageIdentifier,
@@ -214,7 +213,6 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
         .then(() => {
           // Render the example template
           const templateArgs = {
-            name: objectClassName,
             moduleName,
             objectClassName,
             view,

--- a/templates/android.js
+++ b/templates/android.js
@@ -159,10 +159,10 @@ afterEvaluate { project ->
 `,
 }, {
   // for module without view:
-  name: ({ packageIdentifier, name, view }) =>
+  name: ({ objectClassName, packageIdentifier, view }) =>
     !view &&
-      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${name}Module.java`,
-  content: ({ packageIdentifier, name, view }) =>
+      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${objectClassName}Module.java`,
+  content: ({ objectClassName, packageIdentifier, view }) =>
     !view &&
       `package ${packageIdentifier};
 
@@ -171,18 +171,18 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
 
-public class ${name}Module extends ReactContextBaseJavaModule {
+public class ${objectClassName}Module extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
 
-    public ${name}Module(ReactApplicationContext reactContext) {
+    public ${objectClassName}Module(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
     }
 
     @Override
     public String getName() {
-        return "${name}";
+        return "${objectClassName}";
     }
 
     @ReactMethod
@@ -194,10 +194,10 @@ public class ${name}Module extends ReactContextBaseJavaModule {
 `,
 }, {
   // manager for view:
-  name: ({ packageIdentifier, name, view }) =>
+  name: ({ objectClassName, packageIdentifier, view }) =>
     view &&
-      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${name}Manager.java`,
-  content: ({ packageIdentifier, name, view }) =>
+      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${objectClassName}Manager.java`,
+  content: ({ objectClassName, packageIdentifier, view }) =>
     view &&
       `package ${packageIdentifier};
 
@@ -208,9 +208,9 @@ import androidx.appcompat.widget.AppCompatCheckBox;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 
-public class ${name}Manager extends SimpleViewManager<View> {
+public class ${objectClassName}Manager extends SimpleViewManager<View> {
 
-    public static final String REACT_CLASS = "${name}";
+    public static final String REACT_CLASS = "${objectClassName}";
 
     @Override
     public String getName() {
@@ -228,10 +228,10 @@ public class ${name}Manager extends SimpleViewManager<View> {
 `,
 }, {
   // package for module without view:
-  name: ({ packageIdentifier, name, view }) =>
+  name: ({ objectClassName, packageIdentifier, view }) =>
     !view &&
-      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${name}Package.java`,
-  content: ({ packageIdentifier, name, view }) =>
+      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${objectClassName}Package.java`,
+  content: ({ objectClassName, packageIdentifier, view }) =>
     !view &&
       `package ${packageIdentifier};
 
@@ -245,10 +245,10 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.bridge.JavaScriptModule;
 
-public class ${name}Package implements ReactPackage {
+public class ${objectClassName}Package implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Arrays.<NativeModule>asList(new ${name}Module(reactContext));
+        return Arrays.<NativeModule>asList(new ${objectClassName}Module(reactContext));
     }
 
     @Override
@@ -259,10 +259,10 @@ public class ${name}Package implements ReactPackage {
 `,
 }, {
   // package for manager for view:
-  name: ({ packageIdentifier, name, view }) =>
+  name: ({ objectClassName, packageIdentifier, view }) =>
     view &&
-      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${name}Package.java`,
-  content: ({ packageIdentifier, name, view }) =>
+      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${objectClassName}Package.java`,
+  content: ({ objectClassName, packageIdentifier, view }) =>
     view &&
       `package ${packageIdentifier};
 
@@ -276,7 +276,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.bridge.JavaScriptModule;
 
-public class ${name}Package implements ReactPackage {
+public class ${objectClassName}Package implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Collections.emptyList();
@@ -284,7 +284,7 @@ public class ${name}Package implements ReactPackage {
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-        return Arrays.<ViewManager>asList(new ${name}Manager());
+        return Arrays.<ViewManager>asList(new ${objectClassName}Manager());
     }
 }
 `,

--- a/templates/example.js
+++ b/templates/example.js
@@ -185,7 +185,7 @@ module.exports = {
 `,
 }, {
   name: ({ exampleName }) => `${exampleName}/App.js`,
-  content: ({ moduleName, name, view }) =>
+  content: ({ moduleName, objectClassName, view }) =>
     `/**
  * Sample React Native App
  *
@@ -198,7 +198,7 @@ module.exports = {
 
 import React, { Component } from 'react';
 import { Platform, StyleSheet, Text, View } from 'react-native';
-import ${name} from '${moduleName}';` +
+import ${objectClassName} from '${moduleName}';` +
     (!view
       ? `
 
@@ -208,7 +208,7 @@ export default class App extends Component<{}> {
     message: '--'
   };
   componentDidMount() {
-    ${name}.sampleMethod('Testing', 123, (message) => {
+    ${objectClassName}.sampleMethod('Testing', 123, (message) => {
       this.setState({
         status: 'native callback received',
         message
@@ -218,7 +218,7 @@ export default class App extends Component<{}> {
   render() {
     return (
       <View style={styles.container}>
-        <Text style={styles.welcome}>☆${name} example☆</Text>
+        <Text style={styles.welcome}>☆${objectClassName} example☆</Text>
         <Text style={styles.instructions}>STATUS: {this.state.status}</Text>
         <Text style={styles.welcome}>☆NATIVE CALLBACK MESSAGE☆</Text>
         <Text style={styles.instructions}>{this.state.message}</Text>
@@ -232,10 +232,10 @@ export default class App extends Component<{}> {
   render() {
     return (
       <View style={styles.container}>
-        <Text style={styles.welcome}>☆${name} example☆</Text>
+        <Text style={styles.welcome}>☆${objectClassName} example☆</Text>
         <Text style={styles.instructions}>STATUS: loaded</Text>
         <Text style={styles.welcome}>☆☆☆</Text>
-        <${name} />
+        <${objectClassName} />
       </View>
     );
   }

--- a/templates/general.js
+++ b/templates/general.js
@@ -1,6 +1,6 @@
 module.exports = [{
   name: () => 'README.md',
-  content: ({ moduleName, name }) =>
+  content: ({ moduleName, objectClassName }) =>
     `# ${moduleName}
 
 ## Getting started
@@ -13,10 +13,10 @@ module.exports = [{
 
 ## Usage
 \`\`\`javascript
-import ${name} from '${moduleName}';
+import ${objectClassName} from '${moduleName}';
 
 // TODO: What to do with the module?
-${name};
+${objectClassName};
 \`\`\`
 `,
 }, {
@@ -78,22 +78,22 @@ ${name};
 }, {
   // for module without view:
   name: ({ view }) => !view && 'index.js',
-  content: ({ name }) =>
+  content: ({ objectClassName }) =>
     `import { NativeModules } from 'react-native';
 
-const { ${name} } = NativeModules;
+const { ${objectClassName} } = NativeModules;
 
-export default ${name};
+export default ${objectClassName};
 `,
 }, {
   // for module with view:
   name: ({ view }) => view && 'index.js',
-  content: ({ name }) =>
+  content: ({ objectClassName }) =>
     `import { requireNativeComponent } from 'react-native';
 
-const ${name} = requireNativeComponent('${name}', null);
+const ${objectClassName} = requireNativeComponent('${objectClassName}', null);
 
-export default ${name};
+export default ${objectClassName};
 `,
 }, {
   name: () => '.gitignore',

--- a/templates/ios.js
+++ b/templates/ios.js
@@ -31,21 +31,21 @@ end
 `,
 }, {
   // header for module without view:
-  name: ({ name, view }) => !view && `${platform}/${name}.h`,
-  content: ({ name }) => `#import <React/RCTBridgeModule.h>
+  name: ({ objectClassName, view }) => !view && `${platform}/${objectClassName}.h`,
+  content: ({ objectClassName }) => `#import <React/RCTBridgeModule.h>
 
-@interface ${name} : NSObject <RCTBridgeModule>
+@interface ${objectClassName} : NSObject <RCTBridgeModule>
 
 @end
 `,
 }, {
   // implementation of module without view:
-  name: ({ name, view }) => !view && `${platform}/${name}.m`,
-  content: ({ name, useAppleNetworking }) => `#import "${name}.h"
+  name: ({ objectClassName, view }) => !view && `${platform}/${objectClassName}.m`,
+  content: ({ objectClassName, useAppleNetworking }) => `#import "${objectClassName}.h"
 
 ${useAppleNetworking ? `#import <AFNetworking/AFNetworking.h>
 ` : ``}
-@implementation ${name}
+@implementation ${objectClassName}
 
 RCT_EXPORT_MODULE()
 
@@ -71,19 +71,19 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 `,
 }, {
   // header for module with view:
-  name: ({ name, view }) => view && `${platform}/${name}.h`,
-  content: ({ name }) => `#import <React/RCTViewManager.h>
+  name: ({ objectClassName, view }) => view && `${platform}/${objectClassName}.h`,
+  content: ({ objectClassName }) => `#import <React/RCTViewManager.h>
 
-@interface ${name} : RCTViewManager
+@interface ${objectClassName} : RCTViewManager
 
 @end
 `,
 }, {
   // implementation of module with view:
-  name: ({ name, view }) => view && `${platform}/${name}.m`,
-  content: ({ name }) => `#import "${name}.h"
+  name: ({ objectClassName, view }) => view && `${platform}/${objectClassName}.m`,
+  content: ({ objectClassName }) => `#import "${objectClassName}.h"
 
-@implementation ${name}
+@implementation ${objectClassName}
 
 RCT_EXPORT_MODULE()
 
@@ -102,18 +102,18 @@ RCT_EXPORT_MODULE()
 @end
 `,
 }, {
-  name: ({ name }) => `${platform}/${name}.xcworkspace/contents.xcworkspacedata`,
-  content: ({ name }) => `<?xml version="1.0" encoding="UTF-8"?>
+  name: ({ objectClassName }) => `${platform}/${objectClassName}.xcworkspace/contents.xcworkspacedata`,
+  content: ({ objectClassName }) => `<?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:${name}.xcodeproj">
+      location = "group:${objectClassName}.xcodeproj">
    </FileRef>
 </Workspace>
 `,
 }, {
-  name: ({ name }) => `${platform}/${name}.xcodeproj/project.pbxproj`,
-  content: ({ name }) => `// !$*UTF8*$!
+  name: ({ objectClassName }) => `${platform}/${objectClassName}.xcodeproj/project.pbxproj`,
+  content: ({ objectClassName }) => `// !$*UTF8*$!
 {
 	archiveVersion = 1;
 	classes = {
@@ -122,7 +122,7 @@ RCT_EXPORT_MODULE()
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B3E7B58A1CC2AC0600A0062D /* ${name}.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* ${name}.m */; };
+		B3E7B58A1CC2AC0600A0062D /* ${objectClassName}.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* ${objectClassName}.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -138,9 +138,9 @@ RCT_EXPORT_MODULE()
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		134814201AA4EA6300B7C361 /* lib${name}.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = lib${name}.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		B3E7B5881CC2AC0600A0062D /* ${name}.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ${name}.h; sourceTree = "<group>"; };
-		B3E7B5891CC2AC0600A0062D /* ${name}.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ${name}.m; sourceTree = "<group>"; };
+		134814201AA4EA6300B7C361 /* lib${objectClassName}.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = lib${objectClassName}.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E7B5881CC2AC0600A0062D /* ${objectClassName}.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ${objectClassName}.h; sourceTree = "<group>"; };
+		B3E7B5891CC2AC0600A0062D /* ${objectClassName}.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ${objectClassName}.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,7 +157,7 @@ RCT_EXPORT_MODULE()
 		134814211AA4EA7D00B7C361 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				134814201AA4EA6300B7C361 /* lib${name}.a */,
+				134814201AA4EA6300B7C361 /* lib${objectClassName}.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -165,8 +165,8 @@ RCT_EXPORT_MODULE()
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				B3E7B5881CC2AC0600A0062D /* ${name}.h */,
-				B3E7B5891CC2AC0600A0062D /* ${name}.m */,
+				B3E7B5881CC2AC0600A0062D /* ${objectClassName}.h */,
+				B3E7B5891CC2AC0600A0062D /* ${objectClassName}.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -174,9 +174,9 @@ RCT_EXPORT_MODULE()
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		58B511DA1A9E6C8500147676 /* ${name} */ = {
+		58B511DA1A9E6C8500147676 /* ${objectClassName} */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "${name}" */;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "${objectClassName}" */;
 			buildPhases = (
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
@@ -186,9 +186,9 @@ RCT_EXPORT_MODULE()
 			);
 			dependencies = (
 			);
-			name = ${name};
+			name = ${objectClassName};
 			productName = RCTDataManager;
-			productReference = 134814201AA4EA6300B7C361 /* lib${name}.a */;
+			productReference = 134814201AA4EA6300B7C361 /* lib${objectClassName}.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -205,7 +205,7 @@ RCT_EXPORT_MODULE()
 					};
 				};
 			};
-			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "${name}" */;
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "${objectClassName}" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -217,7 +217,7 @@ RCT_EXPORT_MODULE()
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				58B511DA1A9E6C8500147676 /* ${name} */,
+				58B511DA1A9E6C8500147676 /* ${objectClassName} */,
 			);
 		};
 /* End PBXProject section */
@@ -227,7 +227,7 @@ RCT_EXPORT_MODULE()
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3E7B58A1CC2AC0600A0062D /* ${name}.m in Sources */,
+				B3E7B58A1CC2AC0600A0062D /* ${objectClassName}.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -338,7 +338,7 @@ RCT_EXPORT_MODULE()
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = ${name};
+				PRODUCT_NAME = ${objectClassName};
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -354,7 +354,7 @@ RCT_EXPORT_MODULE()
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = ${name};
+				PRODUCT_NAME = ${objectClassName};
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -362,7 +362,7 @@ RCT_EXPORT_MODULE()
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "${name}" */ = {
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "${objectClassName}" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				58B511ED1A9E6C8500147676 /* Debug */,
@@ -371,7 +371,7 @@ RCT_EXPORT_MODULE()
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "${name}" */ = {
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "${objectClassName}" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				58B511F01A9E6C8500147676 /* Debug */,


### PR DESCRIPTION
- use objectClassName instead of name in `templates/*.js`, in followup to object class name updates in 761123b6 / PR #338
- remove `name: objectClassName` template args no longer needed in `lib/lib.js`

(this cleanup should really have been part of PR #338)