### PR TITLE
fix minor indenting issue in ios pbxproj

### DIFF
--- a/templates/ios.js
+++ b/templates/ios.js
@@ -331,7 +331,7 @@ RCT_EXPORT_MODULE()
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				"$(inherited)",
+					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -566,7 +566,7 @@ RCT_EXPORT_MODULE()
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -562,7 +562,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -710,7 +710,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -714,7 +714,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -714,7 +714,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-ios/__snapshots__/create-view-with-options-for-ios.test.js.snap
@@ -440,7 +440,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -706,7 +706,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -710,7 +710,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -710,7 +710,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -710,7 +710,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -716,7 +716,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -706,7 +706,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
+++ b/tests/with-injection/create/with-options/for-ios/__snapshots__/create-with-options-for-ios.test.js.snap
@@ -441,7 +441,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -706,7 +706,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -706,7 +706,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -706,7 +706,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -706,7 +706,7 @@ content:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -694,7 +694,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -765,7 +765,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -765,7 +765,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -765,7 +765,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -759,7 +759,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				\\"$(inherited)\\",
+					\\"$(inherited)\\",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					\\"$(SRCROOT)/../../../React/**\\",
 					\\"$(SRCROOT)/../../react-native/React/**\\",


### PR DESCRIPTION
- fix indenting of `"$(inherited)",` line in generated iOS pbxproj
- update affected test snapshots

discovered when using Xcode to add some dependencies for iOS while working on new SQLite plugin design for React Native, as discussed in <https://github.com/brodybits/ask-me-anything/issues/3>

In short, Xcode actually fixed this indentation issue when I added some other dependencies. I think it would be better to get this right the first time in the generated pbxproj.

TODO:

- [x] I would like to test this with generated example in my workarea before merging and releasing this update.