### PR TITLE
add --swift language option

### DIFF
--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -107,6 +107,9 @@ ${postCreateInstructions(createOptions)}`);
     description: 'Platforms the library module will be created for - comma separated',
     default: 'ios,android',
   }, {
+    command: '--swift',
+    description: 'EXPERIMENAL: Generate the iOS native module in Swift',
+  }, {
     command: '--tvos-enabled',
     description: 'Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)',
   }, {

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -77,6 +77,7 @@ const generateWithNormalizedOptions = ({
   authorEmail = DEFAULT_AUTHOR_EMAIL,
   license = DEFAULT_LICENSE,
   view = false,
+  swift = false,
   useAppleNetworking = false,
   generateExample = DEFAULT_GENERATE_EXAMPLE,
   exampleFileLinkage = false,
@@ -108,6 +109,7 @@ const generateWithNormalizedOptions = ({
      library modulePrefix: ${modulePrefix}
 Android packageIdentifier: ${packageIdentifier}
                 platforms: ${platforms}
+              swift (iOS): ${swift}
         Apple tvosEnabled: ${tvosEnabled}
                authorName: ${authorName}
               authorEmail: ${authorEmail}
@@ -180,6 +182,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
           authorName,
           authorEmail,
           license,
+          swift,
           view,
           useAppleNetworking,
         };

--- a/templates/ios.js
+++ b/templates/ios.js
@@ -30,8 +30,8 @@ end
 
 `,
 }, {
-  // header for module without view:
-  name: ({ objectClassName, view }) => !view && `${platform}/${objectClassName}.h`,
+  // header for Objective-C module without view:
+  name: ({ objectClassName, swift, view }) => !swift && !view && `${platform}/${objectClassName}.h`,
   content: ({ objectClassName }) => `#import <React/RCTBridgeModule.h>
 
 @interface ${objectClassName} : NSObject <RCTBridgeModule>
@@ -40,7 +40,7 @@ end
 `,
 }, {
   // implementation of module without view:
-  name: ({ objectClassName, view }) => !view && `${platform}/${objectClassName}.m`,
+  name: ({ objectClassName, swift, view }) => !swift && !view && `${platform}/${objectClassName}.m`,
   content: ({ objectClassName, useAppleNetworking }) => `#import "${objectClassName}.h"
 
 ${useAppleNetworking ? `#import <AFNetworking/AFNetworking.h>
@@ -69,6 +69,41 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 @end
 `,
+}, {
+  // bridge header for Swift module without view:
+  name: ({ objectClassName, swift, view }) => swift && !view && `${platform}/${objectClassName}-Bridging-Header.h`,
+  content: ({ objectClassName }) => `// ${platform}/${objectClassName}-Bridging-Header.h
+#import <React/RCTBridgeModule.h>
+`,
+}, {
+  // bridge for Swift module without view:
+  name: ({ objectClassName, swift, view }) => swift && !view && `${platform}/${objectClassName}.m`,
+  content: ({ objectClassName, useAppleNetworking }) => `// ${objectClassName}.m
+
+#import <React/RCTBridge.h>
+
+@interface RCT_EXTERN_MODULE(${objectClassName}, NSObject)
+
+RCT_EXTERN_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnull NSNumber *)numberArgument callback:(RCTResponseSenderBlock)callback)
+
+@end
+`,
+}, {
+  // implementation of Swift module without view:
+  name: ({ objectClassName, swift, view }) => swift && !view && `${platform}/${objectClassName}.swift`,
+  content: ({ objectClassName, useAppleNetworking }) => `// ${objectClassName}.swift
+
+import Foundation
+
+@objc(${objectClassName})
+class ${objectClassName} : NSObject {
+  @objc(sampleMethod:numberParameter:callback:)
+  func sampleMethod(stringArgument: String, numberArgument: NSNumber, callback: RCTResponseSenderBlock) -> Void {
+    // TODO: Implement some actually useful functionality
+    callback([String(format: "numberArgument: %@ stringArgument: %@", numberArgument, stringArgument)])
+  }
+}
+`
 }, {
   // header for module with view:
   name: ({ objectClassName, view }) => view && `${platform}/${objectClassName}.h`,

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -14,6 +14,7 @@ Options:
   --module-prefix [modulePrefix]                              The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
+  --swift                                                     EXPERIMENAL: Generate the iOS native module in Swift
   --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
   --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")
   --author-name [authorName]                                  The author's name (default: \\"Your Name\\")

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -14,6 +14,7 @@ Options:
   --module-prefix [modulePrefix]                              The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
   --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
   --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
+  --swift                                                     EXPERIMENAL: Generate the iOS native module in Swift
   --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
   --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")
   --author-name [authorName]                                  The author's name (default: \\"Your Name\\")

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -39,6 +39,10 @@ Object {
       "description": "Platforms the library module will be created for - comma separated",
     },
     Object {
+      "command": "--swift",
+      "description": "EXPERIMENAL: Generate the iOS native module in Swift",
+    },
+    Object {
       "command": "--tvos-enabled",
       "description": "Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)",
     },

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -21,6 +21,7 @@ Array [
      library modulePrefix: react-native
 Android packageIdentifier: com.reactlibrary
                 platforms: bogus
+              swift (iOS): false
         Apple tvosEnabled: false
                authorName: Your Name
               authorEmail: yourname@email.com

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -21,6 +21,7 @@ Array [
      library modulePrefix: react-native
 Android packageIdentifier: com.reactlibrary
                 platforms: 
+              swift (iOS): false
         Apple tvosEnabled: false
                authorName: Your Name
               authorEmail: yourname@email.com

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -21,6 +21,7 @@ Array [
      library modulePrefix: react-native
 Android packageIdentifier: com.reactlibrary
                 platforms: android,ios
+              swift (iOS): false
         Apple tvosEnabled: false
                authorName: Your Name
               authorEmail: yourname@email.com

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -100,6 +100,16 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--swift",
+        "EXPERIMENAL: Generate the iOS native module in Swift",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--tvos-enabled",
         "Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)",
         [Function],

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -98,6 +98,16 @@ Array [
   Object {
     "option": Object {
       "args": Array [
+        "--swift",
+        "EXPERIMENAL: Generate the iOS native module in Swift",
+        [Function],
+        undefined,
+      ],
+    },
+  },
+  Object {
+    "option": Object {
+      "args": Array [
         "--tvos-enabled",
         "Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)",
         [Function],

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -21,6 +21,7 @@ Array [
      library modulePrefix: react-native
 Android packageIdentifier: com.reactlibrary
                 platforms: android,ios
+              swift (iOS): false
         Apple tvosEnabled: false
                authorName: Your Name
               authorEmail: yourname@email.com

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -21,6 +21,7 @@ Array [
      library modulePrefix: react-native
 Android packageIdentifier: com.reactlibrary
                 platforms: android,ios
+              swift (iOS): false
         Apple tvosEnabled: false
                authorName: Your Name
               authorEmail: yourname@email.com

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -21,6 +21,7 @@ Array [
      library modulePrefix: react-native
 Android packageIdentifier: com.reactlibrary
                 platforms: android,ios
+              swift (iOS): false
         Apple tvosEnabled: false
                authorName: Your Name
               authorEmail: yourname@email.com

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -15,6 +15,7 @@ Array [
      library modulePrefix: react-native
 Android packageIdentifier: com.alicebits
                 platforms: android,ios
+              swift (iOS): false
         Apple tvosEnabled: true
                authorName: Alice
               authorEmail: contact@alice.me


### PR DESCRIPTION
- add `--swift` CLI option
- add `swift` option to library API (not documented at this point)
- update iOS template to generate native module with Swift language implementation, if `--swift` option is enabled
- update CLI test snapshots

resolves #221

only tested with React Native 0.62 at this point

I would like to give thanks to the following resources for some extremely helpful guidance for a Swift beginner like myself:

- various comments in #221
- https://reactnative.dev/docs/native-modules-ios.html#exporting-swift
- https://medium.com/javascript-in-plain-english/react-native-native-modules-with-swift-6768ea03b3f
- https://nshipster.com/swift-literals/
- https://stackoverflow.com/questions/24074479/how-to-create-a-string-with-format
- https://moduscreate.com/blog/swift-modules-for-react-native/

and some other interesting resources I found:

- <https://github.com/rhdeck/react-native-swift> (does not seem to be really needed if we generate one -Bridging-Header.h per native module written in Swift as proposed here
- <https://teabreak.e-spres-oh.com/swift-in-react-native-the-ultimate-guide-part-1-modules-9bb8d054db03> (it looks like part 2 could potentially help with the native view part)
- <https://levelup.gitconnected.com/powering-react-native-with-kotlin-swift-support-e5c1210a4e25> (also useful for Kotlin as discussed in #352)

TODO items:

- [ ] resolve an ugly "main queue setup" warning message from the Metro bundler
- [ ] add test cases with `swift` option enabled
- [ ] support native view with Swift language option
- [ ] explicitly reject combination of Swift & Apple Networking options
- [ ] test with tvOS
- [ ] test with other supported React Native versions (0.60, 0.61, 0.63-rc)
- [ ] use Stryker Mutator to check for any missing test cases
- [ ] add documentation

/cc @dlowder-salesforce