### PR TITLE
remove extra blank line from generated iOS module

### DIFF
--- a/templates/ios.js
+++ b/templates/ios.js
@@ -42,8 +42,8 @@ end
   // implementation of module without view:
   name: ({ objectClassName, view }) => !view && `${platform}/${objectClassName}.m`,
   content: ({ objectClassName, useAppleNetworking }) => `#import "${objectClassName}.h"
-
-${useAppleNetworking ? `#import <AFNetworking/AFNetworking.h>
+${useAppleNetworking ? `
+#import <AFNetworking/AFNetworking.h>
 ` : ``}
 @implementation ${objectClassName}
 

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -328,7 +328,6 @@ export default IntegrationTestPackage;
     "name": "react-native-integration-test-package/ios/IntegrationTestPackage.m",
     "theContent": "#import \\"IntegrationTestPackage.h\\"
 
-
 @implementation IntegrationTestPackage
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -457,7 +457,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -461,7 +461,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -461,7 +461,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -461,7 +461,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -457,7 +457,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -457,7 +457,6 @@ content:
 --------
 #import \\"ABCAliceBobbi.h\\"
 
-
 @implementation ABCAliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -457,7 +457,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -457,7 +457,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -457,7 +457,6 @@ content:
 --------
 #import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -449,7 +449,6 @@ end
     "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
     "theContent": "#import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -520,7 +520,6 @@ end
     "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
     "theContent": "#import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -520,7 +520,6 @@ end
     "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
     "theContent": "#import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -520,7 +520,6 @@ end
     "outputFileName": "react-native-alice-bobbi/ios/AliceBobbi.m",
     "theContent": "#import \\"AliceBobbi.h\\"
 
-
 @implementation AliceBobbi
 
 RCT_EXPORT_MODULE()

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -514,7 +514,6 @@ end
     "outputFileName": "react-native-alice-bobbi/ios/ABCAliceBobbi.m",
     "theContent": "#import \\"ABCAliceBobbi.h\\"
 
-
 @implementation ABCAliceBobbi
 
 RCT_EXPORT_MODULE()


### PR DESCRIPTION
tested on:

- React Native 0.62
- react-native-tvos 0.62
- React Native 0.61
- React Native0.60