### PR TITLE
add & use console package

### DIFF
--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -1,3 +1,5 @@
+const { log, error } = require('console');
+
 const emoji = require('node-emoji');
 
 const logSymbols = require('log-symbols');
@@ -69,15 +71,15 @@ module.exports = {
     const rootModuleName = createOptions.moduleName;
 
     return createLibraryModule(createOptions).then(() => {
-      console.log(`
+      log(`
 ${emoji.get('books')}  Created library module ${rootModuleName} in \`./${rootModuleName}\`.
 ${emoji.get('clock9')}  It took ${Date.now() - beforeCreation}ms.
 ${postCreateInstructions(createOptions)}`);
     }).catch((err) => {
-      console.error(`Error while creating library module ${rootModuleName}`);
+      error(`Error while creating library module ${rootModuleName}`);
 
       if (err.stack) {
-        console.error(err.stack);
+        error(err.stack);
       }
     });
   },

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -4,6 +4,8 @@ const path = require('path');
 
 // External imports:
 
+const { log, info, warn, error } = require('console');
+
 // default execa object
 const execaDefault = require('execa');
 
@@ -88,15 +90,15 @@ const generateWithNormalizedOptions = ({
   execa = execaDefault, // (this can be mocked out for testing purposes)
 }) => {
   if (packageIdentifier === DEFAULT_PACKAGE_IDENTIFIER) {
-    console.warn(`While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+    warn(`While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
       identifier, it is recommended to customize the package identifier.`);
   }
 
-  // Note that the some of these console log messages are done as
-  // console.info instead of verbose since they are needed to help
+  // Note that the some of these console log messages are logged as
+  // info instead of verbose since they are needed to help
   // make sense of the console output from the third-party tools.
 
-  console.info(
+  info(
     `CREATE new React Native module with the following options:
 
                      name: ${name}
@@ -135,18 +137,18 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
     const errorRemedyMessage = 'both react-native-cli and yarn CLI tools are needed to generate example project';
 
     try {
-      console.info('CREATE: Check for valid react-native-cli tool version, as needed to generate the example project');
+      info('CREATE: Check for valid react-native-cli tool version, as needed to generate the example project');
       commandSync(reactNativeVersionCommand, checkCliOptions);
-      console.info(`${reactNativeVersionCommand} ok`);
+      info(`${reactNativeVersionCommand} ok`);
     } catch (e) {
       throw new Error(
         `${reactNativeVersionCommand} failed; ${errorRemedyMessage}`);
     }
 
     try {
-      console.info('CREATE: Check for valid Yarn CLI tool version, as needed to generate the example project');
+      info('CREATE: Check for valid Yarn CLI tool version, as needed to generate the example project');
       commandSync(yarnVersionCommand, checkCliOptions);
-      console.info(`${yarnVersionCommand} ok`);
+      info(`${yarnVersionCommand} ok`);
     } catch (e) {
       throw new Error(
         `${yarnVersionCommand} failed; ${errorRemedyMessage}`);
@@ -156,7 +158,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
     // react-native CLI will help the user install this tool if needed.
   }
 
-  console.info('CREATE: Generating the React Native library module');
+  info('CREATE: Generating the React Native library module');
 
   const generateLibraryModule = () => {
     return fs.ensureDir(moduleName).then(() => {
@@ -196,7 +198,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
       const exampleReactNativeInitCommand =
         `react-native init ${exampleName} --version ${exampleReactNativeVersion}`;
 
-      console.info(
+      info(
         `CREATE example app with the following command: ${exampleReactNativeInitCommand}`);
 
       const execOptions = { cwd: `./${moduleName}`, stdio: 'inherit' };
@@ -239,7 +241,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
             // (exampleFileLinkage: true) is used
             // (not needed otherwise):
             if (exampleFileLinkage) {
-              console.info('Adding the cleanup postinstall *workaround* task to the example app');
+              info('Adding the cleanup postinstall *workaround* task to the example app');
               npmAddScriptSync(`${pathExampleApp}/package.json`, {
                 key: 'postinstall',
                 value: `node ../scripts/examples_postinstall.js`
@@ -247,7 +249,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
             }
 
             // Add and link the new library
-            console.info('Linking the new module library to the example app');
+            info('Linking the new module library to the example app');
             const addLinkLibraryCommand = exampleFileLinkage
               ? 'yarn add file:../'
               : 'yarn add link:../';
@@ -255,7 +257,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
             try {
               commandSync(addLinkLibraryCommand, addLinkLibraryOptions);
             } catch (e) {
-              console.error('Yarn failure for example, aborting');
+              error('Yarn failure for example, aborting');
               throw (e);
             }
 
@@ -272,22 +274,21 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
 
               // pod tool is needed at this point for iOS
               try {
-                console.log(
+                log(
                   `check for valid pod version in ${iosExampleAppProjectPath}`);
 
                 commandSync('pod --version', podCommandOptions);
               } catch (e) {
-                console.error('pod --version failure, aborting with broken example app');
+                error('pod --version failure, aborting with broken example app');
                 throw (e);
               }
 
-              console.log(
-                `running pod install in ${iosExampleAppProjectPath}`);
+              log(`running pod install in ${iosExampleAppProjectPath}`);
 
               try {
                 commandSync('pod install', podCommandOptions);
               } catch (e) {
-                console.error('pod install failure, aborting with broken example app');
+                error('pod install failure, aborting with broken example app');
                 throw (e);
               }
             }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "homepage": "https://github.com/brodybits/create-react-native-module#readme",
   "dependencies": {
     "commander": "^6.0.0",
+    "console": "^0.7.2",
     "execa": "^4.0.3",
     "fs-extra": "^9.0.1",
     "jsonfile": "^6.0.1",

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/bogus-name/cli-command-with-bogus-platforms-name.test.js
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/bogus-name/cli-command-with-bogus-platforms-name.test.js
@@ -16,9 +16,7 @@ jest.mock('fs-extra', () => ({
     return Promise.resolve();
   },
 }));
-
-// TBD hackish mock:
-global.console = {
+jest.mock('console', () => ({
   info: (...args) => {
     mockpushit({ info: [].concat(args) });
   },
@@ -34,7 +32,7 @@ global.console = {
   error: (...args) => {
     mockpushit({ error: [].concat(args) });
   },
-};
+}));
 
 test(`create alice-bobbi module with logging, with platforms: 'bogus'`, async () => {
   const args = ['alice-bobbi'];

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/empty-string/cli-command-with-empty-platforms-string.test.js
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/empty-string/cli-command-with-empty-platforms-string.test.js
@@ -16,9 +16,7 @@ jest.mock('fs-extra', () => ({
     return Promise.resolve();
   },
 }));
-
-// TBD hackish mock:
-global.console = {
+jest.mock('console', () => ({
   info: (...args) => {
     mockpushit({ info: [].concat(args) });
   },
@@ -34,7 +32,7 @@ global.console = {
   error: (...args) => {
     mockpushit({ error: [].concat(args) });
   },
-};
+}));
 
 test(`create alice-bobbi module with logging, with platforms: ''`, async () => {
   const args = ['alice-bobbi'];

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-error/cli-command-with-logging-with-error.test.js
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-error/cli-command-with-logging-with-error.test.js
@@ -14,9 +14,7 @@ jest.mock('fs-extra', () => ({
     return Promise.reject(new Error(`ENOPERM not permitted`));
   },
 }));
-
-// TBD hackish mock:
-global.console = {
+jest.mock('console', () => ({
   info: (...args) => {
     mockpushit({ info: [].concat(args) });
   },
@@ -56,7 +54,7 @@ global.console = {
       )
     });
   },
-};
+}));
 
 test('create alice-bobbi module with logging, with fs error (with defaults for Android & iOS)', async () => {
   const args = ['alice-bobbi'];

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/create-with-example-with-defaults.test.js
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/create-with-example-with-defaults.test.js
@@ -32,9 +32,7 @@ jest.mock('execa', () => ({
     mockpushit({ commandSync: command, options });
   }
 }));
-
-// TBD hackish mock:
-global.console = {
+jest.mock('console', () => ({
   info: (...args) => {
     mockpushit({ info: [].concat(args) });
   },
@@ -47,7 +45,7 @@ global.console = {
   error: (...args) => {
     mockpushit({ error: [].concat(args) });
   },
-};
+}));
 
 test('create alice-bobbi module using mocked lib with logging, with example, for Android & iOS with defaults', async () => {
   const options = {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/with-yarn-error-logging.test.js
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/with-yarn-error-logging.test.js
@@ -35,9 +35,7 @@ jest.mock('execa', () => ({
     }
   }
 }));
-
-// TBD hackish mock:
-global.console = {
+jest.mock('console', () => ({
   info: (...args) => {
     mockpushit({ info: [].concat(args) });
   },
@@ -50,7 +48,7 @@ global.console = {
   error: (...args) => {
     mockpushit({ error: [].concat(args) });
   },
-};
+}));
 
 test('create alice-bobbi module using mocked lib with example, with `yarn add` failure with console logging', async () => {
   const options = {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/create-with-example-with-options.test.js
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/create-with-example-with-options.test.js
@@ -32,9 +32,7 @@ jest.mock('execa', () => ({
     mockpushit({ commandSync: command, options });
   }
 }));
-
-// TBD hackish mock:
-global.console = {
+jest.mock('console', () => ({
   info: (...args) => {
     mockpushit({ info: [].concat(args) });
   },
@@ -47,7 +45,7 @@ global.console = {
   error: (...args) => {
     mockpushit({ error: [].concat(args) });
   },
-};
+}));
 
 test('create alice-bobbi module using mocked lib with logging, with example, with prefix: null', async () => {
   const options = {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/create-with-example-with-options.test.js
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/create-with-example-with-options.test.js
@@ -32,9 +32,7 @@ jest.mock('execa', () => ({
     mockpushit({ commandSync: command, options });
   }
 }));
-
-// TBD hackish mock:
-global.console = {
+jest.mock('console', () => ({
   info: (...args) => {
     mockpushit({ info: [].concat(args) });
   },
@@ -47,7 +45,7 @@ global.console = {
   error: (...args) => {
     mockpushit({ error: [].concat(args) });
   },
-};
+}));
 
 test('create alice-bobbi module using mocked lib with logging, with example, for Android & iOS with config options including `exampleFileLinkage: true`', async () => {
   const options = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,6 +1242,11 @@ configstore@^5.0.1:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
+console@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/console/-/console-0.7.2.tgz#f9a4331249291591b7bf9bffa8e205356f20a9f0"
+  integrity sha1-+aQzEkkpFZG3v5v/qOIFNW8gqfA=
+
 contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"


### PR DESCRIPTION
motivation:

- avoid need for hackish `global.console` mocking in some tests
- make it much easier to add test coverage to avoid surviving mutants in these lines: https://github.com/brodybits/create-react-native-module/blob/0.19.0/lib/cli-command.js#L18-L37