### PR TITLE
refactor!: remove JCenter support

### DIFF
--- a/templates/android.js
+++ b/templates/android.js
@@ -32,7 +32,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -69,7 +68,6 @@ repositories {
         url "$rootDir/../node_modules/jsc-android/dist"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -121,6 +121,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -157,6 +158,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
+++ b/tests/integration/cli/create/view/__snapshots__/cli-create-with-view.test.js.snap
@@ -121,7 +121,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -158,7 +157,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -121,6 +121,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -157,6 +158,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
+++ b/tests/integration/cli/create/with-defaults/__snapshots__/cli-create-with-defaults.test.js.snap
@@ -121,7 +121,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -158,7 +157,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -195,6 +195,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -231,6 +232,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-defaults/__snapshots__/create-view-with-defaults.test.js.snap
@@ -195,7 +195,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -232,7 +231,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -199,7 +199,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -236,7 +235,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -199,6 +199,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -235,6 +236,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -199,7 +199,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -236,7 +235,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -199,6 +199,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -235,6 +236,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -163,7 +163,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -200,7 +199,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
+++ b/tests/with-injection/create/view/with-options/for-android/__snapshots__/lib-view-android-config-options.test.js.snap
@@ -163,6 +163,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -199,6 +200,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -195,6 +195,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -231,6 +232,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-defaults/__snapshots__/create-with-defaults.test.js.snap
@@ -195,7 +195,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -232,7 +231,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
+++ b/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
@@ -167,7 +167,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -204,7 +203,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
+++ b/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
@@ -167,6 +167,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -203,6 +204,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -199,7 +199,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -236,7 +235,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -199,6 +199,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -235,6 +236,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -199,7 +199,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -236,7 +235,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
+++ b/tests/with-injection/create/with-example/with-missing-package-scripts/__snapshots__/recover-from-missing-package-scripts.test.js.snap
@@ -199,6 +199,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -235,6 +236,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -199,7 +199,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -236,7 +235,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -199,6 +199,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -235,6 +236,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -199,7 +199,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -236,7 +235,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/with-example/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -199,6 +199,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -235,6 +236,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -195,6 +195,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -231,6 +232,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
+++ b/tests/with-injection/create/with-name-in-camel-case/__snapshots__/create-with-name-in-camel-case.test.js.snap
@@ -195,7 +195,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -232,7 +231,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -163,7 +163,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -200,7 +199,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
+++ b/tests/with-injection/create/with-options/for-android/__snapshots__/create-with-options-for-android.test.js.snap
@@ -163,6 +163,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -199,6 +200,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -195,6 +195,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -231,6 +232,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-array/__snapshots__/platforms-array.test.js.snap
@@ -195,7 +195,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -232,7 +231,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -195,6 +195,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -231,6 +232,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
+++ b/tests/with-injection/create/with-options/platforms-comma-separated/__snapshots__/platforms-comma-separated.test.js.snap
@@ -195,7 +195,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -232,7 +231,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -195,6 +195,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -231,6 +232,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
+++ b/tests/with-injection/create/with-options/with-custom-module-prefix/__snapshots__/create-with-custom-module-prefix.test.js.snap
@@ -195,7 +195,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -232,7 +231,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -195,6 +195,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -231,6 +232,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-module-name/__snapshots__/create-with-module-name.test.js.snap
@@ -195,7 +195,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -232,7 +231,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -201,7 +201,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -238,7 +237,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-options/__snapshots__/cli-command-func-with-options.test.js.snap
@@ -201,6 +201,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -237,6 +238,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -378,6 +378,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -414,6 +415,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -378,7 +378,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -415,7 +414,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
+++ b/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
@@ -486,7 +486,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -523,7 +522,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
+++ b/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
@@ -486,6 +486,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -522,6 +523,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {
@@ -1199,20 +1201,20 @@ YOU'RE ALL SET!
 
 💡 check out the example app in react-native-test-package/undefined
 💡 recommended: run Metro Bundler in a new shell
-[34mℹ[39m (cd react-native-test-package/undefined && yarn start)
+ℹ (cd react-native-test-package/undefined && yarn start)
 💡 enter the following commands to run the example app:
-[34mℹ[39m cd react-native-test-package/undefined
-[34mℹ[39m react-native run-android
-[34mℹ[39m react-native run-ios
-[33m⚠[39m IMPORTANT NOTICES
-[33m⚠[39m After clean checkout, these first steps are needed:
-[34mℹ[39m run Yarn in react-native-test-package/undefined/ios
-[34mℹ[39m (cd react-native-test-package/undefined && yarn)
-[34mℹ[39m do \`pod install\` for iOS in react-native-test-package/undefined/ios
-[34mℹ[39m cd react-native-test-package/undefined
-[34mℹ[39m (cd ios && pod install)
-[33m⚠[39m KNOWN ISSUE with adding dependencies to the library root
-[34mℹ[39m see https://github.com/brodybits/create-react-native-module/issues/308
+ℹ cd react-native-test-package/undefined
+ℹ react-native run-android
+ℹ react-native run-ios
+⚠ IMPORTANT NOTICES
+⚠ After clean checkout, these first steps are needed:
+ℹ run Yarn in react-native-test-package/undefined/ios
+ℹ (cd react-native-test-package/undefined && yarn)
+ℹ do \`pod install\` for iOS in react-native-test-package/undefined/ios
+ℹ cd react-native-test-package/undefined
+ℹ (cd ios && pod install)
+⚠ KNOWN ISSUE with adding dependencies to the library root
+ℹ see https://github.com/brodybits/create-react-native-module/issues/308
 ",
     ],
   },

--- a/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
+++ b/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
@@ -486,7 +486,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -523,7 +522,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {
@@ -1201,20 +1199,20 @@ YOU'RE ALL SET!
 
 💡 check out the example app in react-native-test-package/undefined
 💡 recommended: run Metro Bundler in a new shell
-ℹ (cd react-native-test-package/undefined && yarn start)
+[34mℹ[39m (cd react-native-test-package/undefined && yarn start)
 💡 enter the following commands to run the example app:
-ℹ cd react-native-test-package/undefined
-ℹ react-native run-android
-ℹ react-native run-ios
-⚠ IMPORTANT NOTICES
-⚠ After clean checkout, these first steps are needed:
-ℹ run Yarn in react-native-test-package/undefined/ios
-ℹ (cd react-native-test-package/undefined && yarn)
-ℹ do \`pod install\` for iOS in react-native-test-package/undefined/ios
-ℹ cd react-native-test-package/undefined
-ℹ (cd ios && pod install)
-⚠ KNOWN ISSUE with adding dependencies to the library root
-ℹ see https://github.com/brodybits/create-react-native-module/issues/308
+[34mℹ[39m cd react-native-test-package/undefined
+[34mℹ[39m react-native run-android
+[34mℹ[39m react-native run-ios
+[33m⚠[39m IMPORTANT NOTICES
+[33m⚠[39m After clean checkout, these first steps are needed:
+[34mℹ[39m run Yarn in react-native-test-package/undefined/ios
+[34mℹ[39m (cd react-native-test-package/undefined && yarn)
+[34mℹ[39m do \`pod install\` for iOS in react-native-test-package/undefined/ios
+[34mℹ[39m cd react-native-test-package/undefined
+[34mℹ[39m (cd ios && pod install)
+[33m⚠[39m KNOWN ISSUE with adding dependencies to the library root
+[34mℹ[39m see https://github.com/brodybits/create-react-native-module/issues/308
 ",
     ],
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -272,7 +272,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -309,7 +308,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -272,6 +272,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -308,6 +309,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -272,7 +272,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -309,7 +308,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -272,6 +272,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -308,6 +309,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -272,7 +272,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -309,7 +308,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -272,6 +272,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -308,6 +309,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -266,6 +266,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -302,6 +303,7 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
+    jcenter()
 }
 
 dependencies {

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -266,7 +266,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -303,7 +302,6 @@ repositories {
         url \\"$rootDir/../node_modules/jsc-android/dist\\"
     }
     google()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
seems to be not needed and now deprecated ref:

- https://www.infoq.com/news/2021/02/jfrog-jcenter-bintray-closure/
- https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

BREAKING CHANGE