### PR TITLE
fix: resolve absolute paths in example metro watch folders

### DIFF
--- a/templates/example.js
+++ b/templates/example.js
@@ -145,7 +145,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 `,
 }, {

--- a/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-defaults/__snapshots__/create-view-with-example-with-defaults.test.js.snap
@@ -815,7 +815,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 
 <<<<<<<< ======== >>>>>>>>

--- a/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
+++ b/tests/with-injection/create/view/with-example/with-options/__snapshots__/create-view-with-example-with-options.test.js.snap
@@ -815,7 +815,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 
 <<<<<<<< ======== >>>>>>>>

--- a/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
+++ b/tests/with-injection/create/with-example/for-android-only/__snapshots__/create-with-example-for-android-only.test.js.snap
@@ -414,7 +414,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 
 <<<<<<<< ======== >>>>>>>>

--- a/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-injection/create/with-example/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -810,7 +810,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 
 <<<<<<<< ======== >>>>>>>>

--- a/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
+++ b/tests/with-injection/create/with-example/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-null-prefix.test.js.snap
@@ -810,7 +810,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 
 <<<<<<<< ======== >>>>>>>>

--- a/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
+++ b/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
@@ -1089,7 +1089,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 ",
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -875,7 +875,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 ",
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -875,7 +875,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 ",
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -875,7 +875,7 @@ module.exports = {
   },
 
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
+  watchFolders: [path.resolve('.'), path.resolve('..')]
 }
 ",
   },


### PR DESCRIPTION
similar to: https://github.com/brodybits/react-native-module-init/pull/66

as suggested in: https://github.com/brodybits/create-react-native-module/issues/232#issuecomment-653447868