### PR TITLE
refactor!: rename some options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Options:
   --generate-example                        Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires Yarn to be installed globally
   --example-file-linkage                    DEPRECATED: do `yarn add file:../` instead of `yarn add link:../` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js
   --example-name <exampleName>              Name for the example project (default: `example`)
-  --example-react-native-version <version>  React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (default: `react-native@latest`)
+  --example-react-native-template <...>     React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (default: `react-native@latest`)
   --write-example-podfile                   [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
   -h, --help                                output usage information
 ```
@@ -147,7 +147,7 @@ createLibraryModule({
   generateExample: Boolean, /* Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires Yarn to be installed globally (Default: false) */
   exampleFileLinkage: Boolean, /* DEPRECATED: do `yarn add file:../` instead of `yarn add link:../` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js (Default: false) */
   exampleName: String, /* Name for the example project (Default: `example`) */
-  exampleReactNativeVersion: String, /* React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (Default: `react-native@latest`) */
+  exampleReactNativeTemplate: String, /* React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (Default: `react-native@latest`) */
   writeExamplePodfile: Boolean, /* [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile (Default: false) */
 }
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Usage: create-react-native-module [options] <name>
 Options:
 
   -V, --version                             output the version number
-  --module-name <moduleName>                The module package name to be used in package.json. Default: react-native-(name in param-case)
+  --package-name <packageName>              The module package name to be used in package.json. Default: react-native-(name in param-case)
   --view                                    Generate the package as a very simple native view component
   --object-class-name                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
   --prefix <prefix>                         DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (Default: ``)
@@ -131,7 +131,7 @@ createLibraryModule({
 ```javascript
 {
   name: String, /* The name of the library (mandatory) */
-  moduleName: String, /* The module package name to be used in package.json. Default: react-native-(name in param-case) */
+  packageName: String, /* The module package name to be used in package.json. Default: react-native-(name in param-case) */
   view: Boolean, /* Generate the package as a very simple native view component (Default: false) */
   objectClassName: String, /* The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase) */
   prefix: String, /* DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if objectClassName is specified (Default: ``) */

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ Usage: create-react-native-module [options] <name>
 Options:
 
   -V, --version                             output the version number
-  --package-name <packageName>              The module package name to be used in package.json. Default: react-native-(name in param-case)
+  --package-name <packageName>              The full package name to be used in package.json. Default: react-native-(name in param-case)
   --view                                    Generate the package as a very simple native view component
   --object-class-name                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
   --prefix <prefix>                         DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (Default: ``)
   --module-prefix <modulePrefix>            The prefix of the generated module package name, ignored if --module-name is specified (Default: `react-native`)
-  --native-package-id <nativePackageId>     [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)
+  --native-package-id <nativePackageId>     [Android] The native Java package identifier used for Android (Default: `com.reactlibrary`)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
   --tvos-enabled                            Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
   --github-account <githubAccount>          The github account where the library module is hosted (Default: `github_account`)
@@ -109,7 +109,7 @@ Options:
   --generate-example                        Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires Yarn to be installed globally
   --example-file-linkage                    DEPRECATED: do `yarn add file:../` instead of `yarn add link:../` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js
   --example-name <exampleName>              Name for the example project (default: `example`)
-  --example-react-native-template <...>     React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (default: `react-native@latest`)
+  --example-react-native-template <...>     The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (default: `react-native@latest`)
   --write-example-podfile                   [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
   -h, --help                                output usage information
 ```
@@ -131,13 +131,13 @@ createLibraryModule({
 ```javascript
 {
   name: String, /* The name of the library (mandatory) */
-  packageName: String, /* The module package name to be used in package.json. Default: react-native-(name in param-case) */
+  packageName: String, /* The full package name to be used in package.json. Default: react-native-(name in param-case) */
   view: Boolean, /* Generate the package as a very simple native view component (Default: false) */
   objectClassName: String, /* The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase) */
   prefix: String, /* DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if objectClassName is specified (Default: ``) */
   modulePrefix: String, /* The prefix of the generated module package name, ignored if moduleName is specified (Default: `react-native`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
-  nativePackageId: String, /* [Android] The Java package identifier used by the Android module (Default: com.reactlibrary) */
+  nativePackageId: String, /* [Android] The native Java package identifier used for Android (Default: `com.reactlibrary`) */
   tvosEnabled: Boolean, /* Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled) */
   githubAccount: String, /* The github account where the library is hosted (Default: `github_account`) */
   authorName: String, /* The author's name (Default: `Your Name`) */
@@ -147,7 +147,7 @@ createLibraryModule({
   generateExample: Boolean, /* Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires Yarn to be installed globally (Default: false) */
   exampleFileLinkage: Boolean, /* DEPRECATED: do `yarn add file:../` instead of `yarn add link:../` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js (Default: false) */
   exampleName: String, /* Name for the example project (Default: `example`) */
-  exampleReactNativeTemplate: String, /* React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (Default: `react-native@latest`) */
+  exampleReactNativeTemplate: String, /* The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (Default: `react-native@latest`) */
   writeExamplePodfile: Boolean, /* [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile (Default: false) */
 }
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Options:
   --object-class-name                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
   --prefix <prefix>                         DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (Default: ``)
   --module-prefix <modulePrefix>            The prefix of the generated module package name, ignored if --module-name is specified (Default: `react-native`)
-  --package-identifier <packageIdentifier>  [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)
+  --native-package-id <nativePackageId>     [Android] The Java package identifier used by the Android module (Default: `com.reactlibrary`)
   --platforms <platforms>                   Platforms the library module will be created for - comma separated (Default: `ios,android`)
   --tvos-enabled                            Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
   --github-account <githubAccount>          The github account where the library module is hosted (Default: `github_account`)
@@ -137,7 +137,7 @@ createLibraryModule({
   prefix: String, /* DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if objectClassName is specified (Default: ``) */
   modulePrefix: String, /* The prefix of the generated module package name, ignored if moduleName is specified (Default: `react-native`) */
   platforms: Array | String, /* Platforms the library will be created for. (Default: ['android', 'ios']) */
-  packageIdentifier: String, /* [Android] The Java package identifier used by the Android module (Default: com.reactlibrary) */
+  nativePackageId: String, /* [Android] The Java package identifier used by the Android module (Default: com.reactlibrary) */
   tvosEnabled: Boolean, /* Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled) */
   githubAccount: String, /* The github account where the library is hosted (Default: `github_account`) */
   authorName: String, /* The author's name (Default: `Your Name`) */
@@ -159,7 +159,7 @@ createLibraryModule({
 __Create the module with no view:__
 
 ```console
-create-react-native-module --prefix CB --package-identifier io.mylibrary --generate-example AliceHelper
+create-react-native-module --prefix CB --native-package-id io.mylibrary --generate-example AliceHelper
 ```
 
 The module would be generated in the `react-native-alice-helper` subdirectory, and the example test app would be in `react-native-alice-helper/example`.
@@ -234,7 +234,7 @@ The example app shows the following indications:
 __Create the module with an extremely simple view:__
 
 ```console
-create-react-native-module --prefix CB --package-identifier io.mylibrary --view --generate-example CarolWidget
+create-react-native-module --prefix CB --native-package-id io.mylibrary --view --generate-example CarolWidget
 ```
 
 The module would be generated in the `react-native-carol-widget` subdirectory, and the example test app would be in `react-native-carol-widget/example`.

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -141,7 +141,7 @@ ${postCreateInstructions(createOptions)}`);
     description: 'Name for the example project',
     default: 'example',
   }, {
-    command: '--example-react-native-version [exampleReactNativeVersion]',
+    command: '--example-react-native-template [exampleReactNativeTemplate]',
     description: 'React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62',
     default: 'react-native@latest',
   }, {

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -9,7 +9,7 @@ const normalizedOptions = require('./normalized-options');
 const createLibraryModule = require('./lib');
 
 const postCreateInstructions = ({
-  moduleName,
+  packageName,
   platforms,
   generateExample,
   exampleName
@@ -18,21 +18,21 @@ const postCreateInstructions = ({
 YOU'RE ALL SET!
 ` + (generateExample
     ? `
-${emoji.get('bulb')} check out the example app in ${moduleName}/${exampleName}
+${emoji.get('bulb')} check out the example app in ${packageName}/${exampleName}
 ${emoji.get('bulb')} recommended: run Metro Bundler in a new shell
-${logSymbols.info} (cd ${moduleName}/${exampleName} && yarn start)
+${logSymbols.info} (cd ${packageName}/${exampleName} && yarn start)
 ${emoji.get('bulb')} enter the following commands to run the example app:
-${logSymbols.info} cd ${moduleName}/${exampleName}
+${logSymbols.info} cd ${packageName}/${exampleName}
 ${platforms.split(',').map(platform =>
   `${logSymbols.info} yarn ${platform} # for React Native 0.60: npx react-native run-${platform}`
 ).join(`
 `)}
 ${logSymbols.warning} IMPORTANT NOTICES
 ${logSymbols.warning} After clean checkout, these first steps are needed:
-${logSymbols.info} run Yarn in ${moduleName}/${exampleName}/ios
-${logSymbols.info} (cd ${moduleName}/${exampleName} && yarn)
-${logSymbols.info} do \`pod install\` for iOS in ${moduleName}/${exampleName}/ios
-${logSymbols.info} cd ${moduleName}/${exampleName}
+${logSymbols.info} run Yarn in ${packageName}/${exampleName}/ios
+${logSymbols.info} (cd ${packageName}/${exampleName} && yarn)
+${logSymbols.info} do \`pod install\` for iOS in ${packageName}/${exampleName}/ios
+${logSymbols.info} cd ${packageName}/${exampleName}
 ${logSymbols.info} (cd ios && pod install)
 ${logSymbols.warning} KNOWN ISSUE with adding dependencies to the library root
 ${logSymbols.info} see https://github.com/brodybits/create-react-native-module/issues/308
@@ -68,7 +68,7 @@ module.exports = {
 
     const createOptions = normalizedOptions(preNormalizedOptions);
 
-    const rootModuleName = createOptions.moduleName;
+    const rootModuleName = createOptions.packageName;
 
     return createLibraryModule(createOptions).then(() => {
       info(`
@@ -84,7 +84,7 @@ ${postCreateInstructions(createOptions)}`);
     });
   },
   options: [{
-    command: '--module-name [moduleName]',
+    command: '--package-name [packageName]',
     description: 'The module package name to be used in package.json. Default: react-native-(name in param-case)',
   }, {
     command: '--view',

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -85,7 +85,7 @@ ${postCreateInstructions(createOptions)}`);
   },
   options: [{
     command: '--package-name [packageName]',
-    description: 'The module package name to be used in package.json. Default: react-native-(name in param-case)',
+    description: 'The full package name to be used in package.json. Default: react-native-(name in param-case)',
   }, {
     command: '--view',
     description: 'Generate the package as a very simple native view component',
@@ -102,7 +102,7 @@ ${postCreateInstructions(createOptions)}`);
     default: 'react-native',
   }, {
     command: '--native-package-id [nativePackageId]',
-    description: '[Android] The Java package identifier used by the Android module',
+    description: '[Android] The native Java package identifier used for Android',
     default: 'com.reactlibrary',
   }, {
     command: '--platforms <platforms>',
@@ -142,7 +142,7 @@ ${postCreateInstructions(createOptions)}`);
     default: 'example',
   }, {
     command: '--example-react-native-template [exampleReactNativeTemplate]',
-    description: 'React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62',
+    description: 'The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62',
     default: 'react-native@latest',
   }, {
     command: '--write-example-podfile',

--- a/lib/cli-command.js
+++ b/lib/cli-command.js
@@ -101,7 +101,7 @@ ${postCreateInstructions(createOptions)}`);
     description: 'The prefix of the generated module package name, ignored if --module-name is specified',
     default: 'react-native',
   }, {
-    command: '--package-identifier [packageIdentifier]',
+    command: '--native-package-id [nativePackageId]',
     description: '[Android] The Java package identifier used by the Android module',
     default: 'com.reactlibrary',
   }, {

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -105,28 +105,28 @@ const generateWithNormalizedOptions = ({
   info(
     `CREATE new React Native module with the following options:
 
-                     name: ${name}
-    root moduleName
-      (full package name): ${packageName}
-                  is view: ${view}
- object class name prefix: ${prefix}
-        object class name: ${objectClassName}
-     library modulePrefix: ${modulePrefix}
-  Android nativePackageId: ${nativePackageId}
-                platforms: ${platforms}
-        Apple tvosEnabled: ${tvosEnabled}
-               authorName: ${authorName}
-              authorEmail: ${authorEmail}
-     author githubAccount: ${githubAccount}
-                  license: ${license}
-       useAppleNetworking: ${useAppleNetworking}
+                      name: ${name}
+     root moduleName
+       (full package name): ${packageName}
+                   is view: ${view}
+  object class name prefix: ${prefix}
+         object class name: ${objectClassName}
+      library modulePrefix: ${modulePrefix}
+   Android nativePackageId: ${nativePackageId}
+                 platforms: ${platforms}
+         Apple tvosEnabled: ${tvosEnabled}
+                authorName: ${authorName}
+               authorEmail: ${authorEmail}
+      author githubAccount: ${githubAccount}
+                   license: ${license}
+        useAppleNetworking: ${useAppleNetworking}
 ` + (generateExample
       ? `
-          generateExample: ${generateExample}
-       exampleFileLinkage: ${exampleFileLinkage}
-              exampleName: ${exampleName}
+           generateExample: ${generateExample}
+        exampleFileLinkage: ${exampleFileLinkage}
+               exampleName: ${exampleName}
 exampleReactNativeTemplate: ${exampleReactNativeTemplate}
-      writeExamplePodfile: ${writeExamplePodfile}
+       writeExamplePodfile: ${writeExamplePodfile}
 ` : ``));
 
   // QUICK LOCAL INJECTION overwite of existing execSync / commandSync call from

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -68,7 +68,7 @@ const npmAddScriptSync = (packageJsonPath, script, fs) => {
 const generateWithNormalizedOptions = ({
   name,
   prefix, // (only needed for logging purposes in this function)
-  moduleName,
+  packageName,
   objectClassName,
   modulePrefix,
   packageIdentifier = DEFAULT_PACKAGE_IDENTIFIER,
@@ -107,7 +107,7 @@ const generateWithNormalizedOptions = ({
 
                      name: ${name}
     root moduleName
-      (full package name): ${moduleName}
+      (full package name): ${packageName}
                   is view: ${view}
  object class name prefix: ${prefix}
         object class name: ${objectClassName}
@@ -153,7 +153,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
   info('CREATE: Generating the React Native library module');
 
   const generateLibraryModule = () => {
-    return fs.ensureDir(moduleName).then(() => {
+    return fs.ensureDir(packageName).then(() => {
       return Promise.all(templates.filter((template) => {
         if (template.platform) {
           return (platforms.indexOf(template.platform) >= 0);
@@ -162,7 +162,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
         return true;
       }).map((template) => {
         const templateArgs = {
-          moduleName,
+          packageName,
           objectClassName,
           packageIdentifier,
           // namespace - library API member removed since Windows platform
@@ -178,7 +178,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
           useAppleNetworking,
         };
 
-        return renderTemplateIfValid(fs, moduleName, template, templateArgs);
+        return renderTemplateIfValid(fs, packageName, template, templateArgs);
       }));
     });
   };
@@ -194,9 +194,9 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
       // react-native-init-func function call
       // which may affect the process cwd state
       // (absolute paths seem to be needed for the steps below function properly)
-      const modulePath = path.resolve('.', moduleName);
+      const modulePath = path.resolve('.', packageName);
       const pathExampleApp = path.join(modulePath, exampleName);
-      const exampleAppSubdirectory = path.join('.', moduleName, exampleName);
+      const exampleAppSubdirectory = path.join('.', packageName, exampleName);
 
       // (with the work done in a promise chain)
       return Promise.resolve()
@@ -209,7 +209,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
         .then(() => {
           // Render the example template
           const templateArgs = {
-            moduleName,
+            packageName,
             objectClassName,
             view,
             useAppleNetworking,

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -106,8 +106,7 @@ const generateWithNormalizedOptions = ({
     `CREATE new React Native module with the following options:
 
                       name: ${name}
-     root moduleName
-       (full package name): ${packageName}
+        full package name: ${packageName}
                    is view: ${view}
   object class name prefix: ${prefix}
          object class name: ${objectClassName}

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -26,7 +26,7 @@ const normalizedOptions = require('./normalized-options');
 const templates = require('../templates');
 const exampleTemplates = require('../templates/example');
 
-const DEFAULT_PACKAGE_IDENTIFIER = 'com.reactlibrary';
+const DEFAULT_NATIVE_PACKAGE_ID = 'com.reactlibrary';
 const DEFAULT_PLATFORMS = ['android', 'ios'];
 const DEFAULT_GITHUB_ACCOUNT = 'github_account';
 const DEFAULT_AUTHOR_NAME = 'Your Name';
@@ -34,7 +34,7 @@ const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com';
 const DEFAULT_LICENSE = 'MIT';
 const DEFAULT_GENERATE_EXAMPLE = false;
 const DEFAULT_EXAMPLE_NAME = 'example';
-const DEFAULT_EXAMPLE_REACT_NATIVE_VERSION = 'react-native@latest';
+const DEFAULT_EXAMPLE_REACT_NATIVE_TEMPLATE = 'react-native@latest';
 
 const renderTemplateIfValid = (fs, root, template, templateArgs) => {
   // avoid throwing an exception in case there is no valid template.name member
@@ -71,7 +71,7 @@ const generateWithNormalizedOptions = ({
   packageName,
   objectClassName,
   modulePrefix,
-  nativePackageId = DEFAULT_PACKAGE_IDENTIFIER,
+  nativePackageId = DEFAULT_NATIVE_PACKAGE_ID,
   // namespace - library API member removed since Windows platform
   // is now removed (may be added back someday in the future)
   // namespace,
@@ -86,15 +86,15 @@ const generateWithNormalizedOptions = ({
   generateExample = DEFAULT_GENERATE_EXAMPLE,
   exampleFileLinkage = false,
   exampleName = DEFAULT_EXAMPLE_NAME,
-  exampleReactNativeTemplate = DEFAULT_EXAMPLE_REACT_NATIVE_VERSION,
+  exampleReactNativeTemplate = DEFAULT_EXAMPLE_REACT_NATIVE_TEMPLATE,
   writeExamplePodfile = false,
 }, {
   fs = fsExtra, // (this can be mocked out for testing purposes)
   execa = execaDefault, // (this can be mocked out for testing purposes)
   reactNativeInit = reactNativeInitDefault // (can be overridden or mocked out for testing purposes)
 }) => {
-  if (nativePackageId === DEFAULT_PACKAGE_IDENTIFIER) {
-    warn(`While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+  if (nativePackageId === DEFAULT_NATIVE_PACKAGE_ID) {
+    warn(`While \`{DEFAULT_NATIVE_PACKAGE_ID}\` is the default package
       identifier, it is recommended to customize the package identifier.`);
   }
 

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -86,7 +86,7 @@ const generateWithNormalizedOptions = ({
   generateExample = DEFAULT_GENERATE_EXAMPLE,
   exampleFileLinkage = false,
   exampleName = DEFAULT_EXAMPLE_NAME,
-  exampleReactNativeVersion = DEFAULT_EXAMPLE_REACT_NATIVE_VERSION,
+  exampleReactNativeTemplate = DEFAULT_EXAMPLE_REACT_NATIVE_VERSION,
   writeExamplePodfile = false,
 }, {
   fs = fsExtra, // (this can be mocked out for testing purposes)
@@ -125,7 +125,7 @@ const generateWithNormalizedOptions = ({
           generateExample: ${generateExample}
        exampleFileLinkage: ${exampleFileLinkage}
               exampleName: ${exampleName}
-exampleReactNativeVersion: ${exampleReactNativeVersion}
+exampleReactNativeTemplate: ${exampleReactNativeTemplate}
       writeExamplePodfile: ${writeExamplePodfile}
 ` : ``));
 
@@ -187,8 +187,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
   // multiple test or sample apps in the future.
   const generateExampleApp =
     () => {
-      // TODO: rename --example-react-native-version to --example-react-native-template
-      info(`CREATE example app with the following template: ${exampleReactNativeVersion}`);
+      info(`CREATE example app with the following template: ${exampleReactNativeTemplate}`);
 
       // resolve **absolute** module & example paths before
       // react-native-init-func function call
@@ -202,7 +201,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
       return Promise.resolve()
         .then(() => {
           return reactNativeInit([exampleName], {
-            template: exampleReactNativeVersion,
+            template: exampleReactNativeTemplate,
             directory: exampleAppSubdirectory
           });
         })

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -71,7 +71,7 @@ const generateWithNormalizedOptions = ({
   packageName,
   objectClassName,
   modulePrefix,
-  packageIdentifier = DEFAULT_PACKAGE_IDENTIFIER,
+  nativePackageId = DEFAULT_PACKAGE_IDENTIFIER,
   // namespace - library API member removed since Windows platform
   // is now removed (may be added back someday in the future)
   // namespace,
@@ -93,7 +93,7 @@ const generateWithNormalizedOptions = ({
   execa = execaDefault, // (this can be mocked out for testing purposes)
   reactNativeInit = reactNativeInitDefault // (can be overridden or mocked out for testing purposes)
 }) => {
-  if (packageIdentifier === DEFAULT_PACKAGE_IDENTIFIER) {
+  if (nativePackageId === DEFAULT_PACKAGE_IDENTIFIER) {
     warn(`While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
       identifier, it is recommended to customize the package identifier.`);
   }
@@ -112,7 +112,7 @@ const generateWithNormalizedOptions = ({
  object class name prefix: ${prefix}
         object class name: ${objectClassName}
      library modulePrefix: ${modulePrefix}
-Android packageIdentifier: ${packageIdentifier}
+  Android nativePackageId: ${nativePackageId}
                 platforms: ${platforms}
         Apple tvosEnabled: ${tvosEnabled}
                authorName: ${authorName}
@@ -164,7 +164,7 @@ exampleReactNativeVersion: ${exampleReactNativeVersion}
         const templateArgs = {
           packageName,
           objectClassName,
-          packageIdentifier,
+          nativePackageId,
           // namespace - library API member removed since Windows platform
           // is now removed (may be added back someday in the future)
           // namespace,

--- a/lib/normalized-options.js
+++ b/lib/normalized-options.js
@@ -6,7 +6,7 @@ const { pascalCase } = require('pascal-case');
 const DEFAULT_MODULE_PREFIX = 'react-native';
 
 module.exports = (options) => {
-  const { name, moduleName, objectClassName } = options;
+  const { name, packageName, objectClassName } = options;
 
   const prefix = options.prefix || '';
 
@@ -23,9 +23,9 @@ module.exports = (options) => {
   return Object.assign(
     { name, prefix, modulePrefix },
     options,
-    moduleName
+    packageName
       ? {}
-      : { moduleName: `${modulePrefix}-${paramCase(name)}` },
+      : { packageName: `${modulePrefix}-${paramCase(name)}` },
     objectClassName
       ? {}
       : { objectClassName: `${prefix}${pascalCase(name)}` },

--- a/templates/android.js
+++ b/templates/android.js
@@ -1,6 +1,6 @@
 module.exports = platform => [{
   name: () => `${platform}/build.gradle`,
-  content: ({ packageIdentifier }) => `// ${platform}/build.gradle
+  content: ({ nativePackageId }) => `// ${platform}/build.gradle
 
 // based on:
 //
@@ -83,7 +83,7 @@ def configureReactNativePom(def pom) {
         name packageJson.title
         artifactId packageJson.name
         version = packageJson.version
-        group = "${packageIdentifier}"
+        group = "${nativePackageId}"
         description packageJson.description
         url packageJson.repository.baseUrl
 
@@ -151,23 +151,23 @@ afterEvaluate { project ->
 `,
 }, {
   name: () => `${platform}/src/main/AndroidManifest.xml`,
-  content: ({ packageIdentifier }) => `<!-- AndroidManifest.xml -->
+  content: ({ nativePackageId }) => `<!-- AndroidManifest.xml -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="${packageIdentifier}">
+          package="${nativePackageId}">
 
 </manifest>
 `,
 }, {
   // for module without view:
-  name: ({ objectClassName, packageIdentifier, view }) =>
+  name: ({ objectClassName, nativePackageId, view }) =>
     !view &&
-      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${objectClassName}Module.java`,
-  content: ({ objectClassName, packageIdentifier, view }) =>
+      `${platform}/src/main/java/${nativePackageId.split('.').join('/')}/${objectClassName}Module.java`,
+  content: ({ objectClassName, nativePackageId, view }) =>
     !view &&
       `// ${objectClassName}Module.java
 
-package ${packageIdentifier};
+package ${nativePackageId};
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -197,14 +197,14 @@ public class ${objectClassName}Module extends ReactContextBaseJavaModule {
 `,
 }, {
   // manager for view:
-  name: ({ objectClassName, packageIdentifier, view }) =>
+  name: ({ objectClassName, nativePackageId, view }) =>
     view &&
-      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${objectClassName}Manager.java`,
-  content: ({ objectClassName, packageIdentifier, view }) =>
+      `${platform}/src/main/java/${nativePackageId.split('.').join('/')}/${objectClassName}Manager.java`,
+  content: ({ objectClassName, nativePackageId, view }) =>
     view &&
       `// ${objectClassName}Manager.java
 
-package ${packageIdentifier};
+package ${nativePackageId};
 
 import android.view.View;
 
@@ -233,14 +233,14 @@ public class ${objectClassName}Manager extends SimpleViewManager<View> {
 `,
 }, {
   // package for module without view:
-  name: ({ objectClassName, packageIdentifier, view }) =>
+  name: ({ objectClassName, nativePackageId, view }) =>
     !view &&
-      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${objectClassName}Package.java`,
-  content: ({ objectClassName, packageIdentifier, view }) =>
+      `${platform}/src/main/java/${nativePackageId.split('.').join('/')}/${objectClassName}Package.java`,
+  content: ({ objectClassName, nativePackageId, view }) =>
     !view &&
       `// ${objectClassName}Package.java
 
-package ${packageIdentifier};
+package ${nativePackageId};
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -265,14 +265,14 @@ public class ${objectClassName}Package implements ReactPackage {
 `,
 }, {
   // package for manager for view:
-  name: ({ objectClassName, packageIdentifier, view }) =>
+  name: ({ objectClassName, nativePackageId, view }) =>
     view &&
-      `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${objectClassName}Package.java`,
-  content: ({ objectClassName, packageIdentifier, view }) =>
+      `${platform}/src/main/java/${nativePackageId.split('.').join('/')}/${objectClassName}Package.java`,
+  content: ({ objectClassName, nativePackageId, view }) =>
     view &&
       `// ${objectClassName}Package.java
 
-package ${packageIdentifier};
+package ${nativePackageId};
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/templates/example.js
+++ b/templates/example.js
@@ -121,7 +121,7 @@ module.exports = [{
   // metro.config.js workarounds needed in case of `exampleFileLinkage: false`:
   name: ({ exampleName, exampleFileLinkage }) =>
     exampleFileLinkage ? undefined : `${exampleName}/metro.config.js`,
-  content: ({ moduleName, exampleName }) => `// metro.config.js
+  content: ({ packageName, exampleName }) => `// metro.config.js
 //
 // with multiple workarounds for this issue with symlinks:
 // https://github.com/facebook/metro/issues/1
@@ -153,7 +153,7 @@ module.exports = {
 }, {
   name: ({ exampleName, writeExamplePodfile }) =>
     writeExamplePodfile ? `${exampleName}/ios/Podfile` : undefined,
-  content: ({ moduleName, exampleName }) =>
+  content: ({ packageName, exampleName }) =>
     outdent({ trimTrailingNewline: false })`
 	platform :ios, '10.0'
 
@@ -184,12 +184,12 @@ module.exports = {
 			'DevSupport'
 		]
 
-		pod '${moduleName}', :path => '../../${moduleName}.podspec'
+		pod '${packageName}', :path => '../../${packageName}.podspec'
 	end
 `,
 }, {
   name: ({ exampleName }) => `${exampleName}/App.js`,
-  content: ({ moduleName, objectClassName, view }) =>
+  content: ({ packageName, objectClassName, view }) =>
     `/**
  * Sample React Native App
  *
@@ -202,7 +202,7 @@ module.exports = {
 
 import React, { Component } from 'react';
 import { Platform, StyleSheet, Text, View } from 'react-native';
-import ${objectClassName} from '${moduleName}';` +
+import ${objectClassName} from '${packageName}';` +
     (!view
       ? `
 

--- a/templates/general.js
+++ b/templates/general.js
@@ -1,19 +1,19 @@
 module.exports = [{
   name: () => 'README.md',
-  content: ({ moduleName, objectClassName }) =>
-    `# ${moduleName}
+  content: ({ packageName, objectClassName }) =>
+    `# ${packageName}
 
 ## Getting started
 
-\`$ npm install ${moduleName} --save\`
+\`$ npm install ${packageName} --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link ${moduleName}\`
+\`$ react-native link ${packageName}\`
 
 ## Usage
 \`\`\`javascript
-import ${objectClassName} from '${moduleName}';
+import ${objectClassName} from '${packageName}';
 
 // TODO: What to do with the module?
 ${objectClassName};
@@ -21,7 +21,7 @@ ${objectClassName};
 `,
 }, {
   name: () => 'package.json',
-  content: ({ moduleName, platforms, githubAccount, authorName, authorEmail, license }) => {
+  content: ({ packageName, platforms, githubAccount, authorName, authorEmail, license }) => {
     const files =
       `[
     "README.md",` +
@@ -30,7 +30,7 @@ ${objectClassName};
     "index.js"` +
     (platforms.indexOf('ios') >= 0 ? `,
     "ios",
-    "${moduleName}.podspec"` : ``) + `
+    "${packageName}.podspec"` : ``) + `
   ]`;
 
     const peerDependencies =
@@ -46,8 +46,8 @@ ${objectClassName};
   }`;
 
     return `{
-  "name": "${moduleName}",
-  "title": "${moduleName.split('-').map(word => word[0].toUpperCase() + word.substr(1)).join(' ')}",
+  "name": "${packageName}",
+  "title": "${packageName.split('-').map(word => word[0].toUpperCase() + word.substr(1)).join(' ')}",
   "version": "1.0.0",
   "description": "TODO",
   "main": "index.js",
@@ -57,8 +57,8 @@ ${objectClassName};
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/${githubAccount}/${moduleName}.git",
-    "baseUrl": "https://github.com/${githubAccount}/${moduleName}"
+    "url": "git+https://github.com/${githubAccount}/${packageName}.git",
+    "baseUrl": "https://github.com/${githubAccount}/${packageName}"
   },
   "keywords": [
     "react-native"

--- a/templates/ios.js
+++ b/templates/ios.js
@@ -1,27 +1,27 @@
 module.exports = platform => [{
-  name: ({ moduleName }) => `${moduleName}.podspec`,
-  content: ({ moduleName, tvosEnabled, githubAccount, authorName, authorEmail, license, useAppleNetworking }) =>
-    `# ${moduleName}.podspec
+  name: ({ packageName }) => `${packageName}.podspec`,
+  content: ({ packageName, tvosEnabled, githubAccount, authorName, authorEmail, license, useAppleNetworking }) =>
+    `# ${packageName}.podspec
 
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name         = "${moduleName}"
+  s.name         = "${packageName}"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.description  = <<-DESC
-                  ${moduleName}
+                  ${packageName}
                    DESC
-  s.homepage     = "https://github.com/${githubAccount}/${moduleName}"
+  s.homepage     = "https://github.com/${githubAccount}/${packageName}"
   # brief license entry:
   s.license      = "${license}"
   # optional - use expanded license entry instead:
   # s.license    = { :type => "${license}", :file => "LICENSE" }
   s.authors      = { "${authorName}" => "${authorEmail}" }
   s.platforms    = { :ios => "9.0"${tvosEnabled ? `, :tvos => "10.0"` : ``} }
-  s.source       = { :git => "https://github.com/${githubAccount}/${moduleName}.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/${githubAccount}/${packageName}.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,c,cc,cpp,m,mm,swift}"
   s.requires_arc = true

--- a/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
+++ b/tests/integration/cli/help/__snapshots__/cli-help.test.js.snap
@@ -6,24 +6,24 @@ exports[`bin/cli.js --help returns expected output 1`] = `
 creates a React Native library module for one or more platforms
 
 Options:
-  -V, --version                                               output the version number
-  --module-name [moduleName]                                  The module package name to be used in package.json. Default: react-native-(name in param-case)
-  --view                                                      Generate the package as a very simple native view component
-  --object-class-name [objectClassName]                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
-  --prefix [prefix]                                           DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (default: \\"\\")
-  --module-prefix [modulePrefix]                              The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
-  --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
-  --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
-  --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
-  --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")
-  --author-name [authorName]                                  The author's name (default: \\"Your Name\\")
-  --author-email [authorEmail]                                The author's email (default: \\"yourname@email.com\\")
-  --license [license]                                         The license type (default: \\"MIT\\")
-  --use-apple-networking                                      [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
-  --generate-example                                          Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires Yarn to be installed globally
-  --example-file-linkage                                      DEPRECATED: do \`yarn add file:../\` instead of \`yarn add link:../\` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js
-  --example-name [exampleName]                                Name for the example project (default: \\"example\\")
-  --example-react-native-version [exampleReactNativeVersion]  React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (default: \\"react-native@latest\\")
-  --write-example-podfile                                     [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
-  -h, --help                                                  display help for command"
+  -V, --version                                                 output the version number
+  --package-name [packageName]                                  The full package name to be used in package.json. Default: react-native-(name in param-case)
+  --view                                                        Generate the package as a very simple native view component
+  --object-class-name [objectClassName]                         The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
+  --prefix [prefix]                                             DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (default: \\"\\")
+  --module-prefix [modulePrefix]                                The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
+  --native-package-id [nativePackageId]                         [Android] The native Java package identifier used for Android (default: \\"com.reactlibrary\\")
+  --platforms <platforms>                                       Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
+  --tvos-enabled                                                Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
+  --github-account [githubAccount]                              The github account where the library module is hosted (default: \\"github_account\\")
+  --author-name [authorName]                                    The author's name (default: \\"Your Name\\")
+  --author-email [authorEmail]                                  The author's email (default: \\"yourname@email.com\\")
+  --license [license]                                           The license type (default: \\"MIT\\")
+  --use-apple-networking                                        [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
+  --generate-example                                            Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires Yarn to be installed globally
+  --example-file-linkage                                        DEPRECATED: do \`yarn add file:../\` instead of \`yarn add link:../\` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js
+  --example-name [exampleName]                                  Name for the example project (default: \\"example\\")
+  --example-react-native-template [exampleReactNativeTemplate]  The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (default: \\"react-native@latest\\")
+  --write-example-podfile                                       [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
+  -h, --help                                                    display help for command"
 `;

--- a/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
+++ b/tests/integration/cli/noargs/__snapshots__/cli-noargs.test.js.snap
@@ -6,24 +6,24 @@ exports[`bin/cli.js with no arguments returns expected output 1`] = `
 creates a React Native library module for one or more platforms
 
 Options:
-  -V, --version                                               output the version number
-  --module-name [moduleName]                                  The module package name to be used in package.json. Default: react-native-(name in param-case)
-  --view                                                      Generate the package as a very simple native view component
-  --object-class-name [objectClassName]                       The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
-  --prefix [prefix]                                           DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (default: \\"\\")
-  --module-prefix [modulePrefix]                              The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
-  --package-identifier [packageIdentifier]                    [Android] The Java package identifier used by the Android module (default: \\"com.reactlibrary\\")
-  --platforms <platforms>                                     Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
-  --tvos-enabled                                              Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
-  --github-account [githubAccount]                            The github account where the library module is hosted (default: \\"github_account\\")
-  --author-name [authorName]                                  The author's name (default: \\"Your Name\\")
-  --author-email [authorEmail]                                The author's email (default: \\"yourname@email.com\\")
-  --license [license]                                         The license type (default: \\"MIT\\")
-  --use-apple-networking                                      [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
-  --generate-example                                          Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires Yarn to be installed globally
-  --example-file-linkage                                      DEPRECATED: do \`yarn add file:../\` instead of \`yarn add link:../\` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js
-  --example-name [exampleName]                                Name for the example project (default: \\"example\\")
-  --example-react-native-version [exampleReactNativeVersion]  React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (default: \\"react-native@latest\\")
-  --write-example-podfile                                     [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
-  -h, --help                                                  display help for command"
+  -V, --version                                                 output the version number
+  --package-name [packageName]                                  The full package name to be used in package.json. Default: react-native-(name in param-case)
+  --view                                                        Generate the package as a very simple native view component
+  --object-class-name [objectClassName]                         The name of the object class to be exported by both JavaScript and native code. Default: (name in PascalCase)
+  --prefix [prefix]                                             DEPRECATED: The prefix of the name of the object class to be exported by both JavaScript and native code, ignored if --object-class-name is specified (default: \\"\\")
+  --module-prefix [modulePrefix]                                The prefix of the generated module package name, ignored if --module-name is specified (default: \\"react-native\\")
+  --native-package-id [nativePackageId]                         [Android] The native Java package identifier used for Android (default: \\"com.reactlibrary\\")
+  --platforms <platforms>                                       Platforms the library module will be created for - comma separated (default: \\"ios,android\\")
+  --tvos-enabled                                                Generate the module with tvOS build enabled (requires react-native-tvos fork, with minimum version of 0.60, and iOS platform to be enabled)
+  --github-account [githubAccount]                              The github account where the library module is hosted (default: \\"github_account\\")
+  --author-name [authorName]                                    The author's name (default: \\"Your Name\\")
+  --author-email [authorEmail]                                  The author's email (default: \\"yourname@email.com\\")
+  --license [license]                                           The license type (default: \\"MIT\\")
+  --use-apple-networking                                        [iOS] Use \`AFNetworking\` dependency as a sample in the podspec & use it from the iOS code
+  --generate-example                                            Generate an example project and add the library module to it with symlink by defult, with overwrite of example metro.config.js to add workaround for Metro symlink issue - requires Yarn to be installed globally
+  --example-file-linkage                                        DEPRECATED: do \`yarn add file:../\` instead of \`yarn add link:../\` in a generated example project, and add a postinstall workaround script, with no overwrite of example metro.config.js
+  --example-name [exampleName]                                  Name for the example project (default: \\"example\\")
+  --example-react-native-template [exampleReactNativeTemplate]  The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62 (default: \\"react-native@latest\\")
+  --write-example-podfile                                       [iOS] EXPERIMENTAL FEATURE NOT SUPPORTED: write (or overwrite) example ios/Podfile
+  -h, --help                                                    display help for command"
 `;

--- a/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
+++ b/tests/with-injection/cli/command/object/__snapshots__/lib-cli-command-object-text.test.js.snap
@@ -7,8 +7,8 @@ Object {
   "name": "create-library",
   "options": Array [
     Object {
-      "command": "--module-name [moduleName]",
-      "description": "The module package name to be used in package.json. Default: react-native-(name in param-case)",
+      "command": "--package-name [packageName]",
+      "description": "The full package name to be used in package.json. Default: react-native-(name in param-case)",
     },
     Object {
       "command": "--view",
@@ -29,9 +29,9 @@ Object {
       "description": "The prefix of the generated module package name, ignored if --module-name is specified",
     },
     Object {
-      "command": "--package-identifier [packageIdentifier]",
+      "command": "--native-package-id [nativePackageId]",
       "default": "com.reactlibrary",
-      "description": "[Android] The Java package identifier used by the Android module",
+      "description": "[Android] The native Java package identifier used for Android",
     },
     Object {
       "command": "--platforms <platforms>",
@@ -80,9 +80,9 @@ Object {
       "description": "Name for the example project",
     },
     Object {
-      "command": "--example-react-native-version [exampleReactNativeVersion]",
+      "command": "--example-react-native-template [exampleReactNativeTemplate]",
       "default": "react-native@latest",
-      "description": "React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62",
+      "description": "The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62",
     },
     Object {
       "command": "--write-example-podfile",

--- a/tests/with-injection/create/view/with-example/with-options/create-view-with-example-with-options.test.js
+++ b/tests/with-injection/create/view/with-example/with-options/create-view-with-example-with-options.test.js
@@ -17,7 +17,7 @@ test('create alice-bobbi view module with example, with custom config options', 
     view: true,
     generateExample: true,
     exampleName: 'test-demo',
-    exampleReactNativeVersion: 'react-native@0.60',
+    exampleReactNativeTemplate: 'react-native@0.60',
   };
 
   return lib(options, inject)

--- a/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
+++ b/tests/with-injection/create/with-example/with-options/create-with-example-with-options.test.js
@@ -18,7 +18,7 @@ test('create alice-bobbi module with example, with config options including `exa
     generateExample: true,
     exampleFileLinkage: true,
     exampleName: 'test-demo',
-    exampleReactNativeVersion: 'react-native@0.60',
+    exampleReactNativeTemplate: 'react-native@0.60',
     useAppleNetworking: true,
     writeExamplePodfile: true,
   };

--- a/tests/with-injection/create/with-options/for-android/create-with-options-for-android.test.js
+++ b/tests/with-injection/create/with-options/for-android/create-with-options-for-android.test.js
@@ -10,7 +10,7 @@ test('create alice-bobbi module with config options for Android only', () => {
   const options = {
     platforms: ['android'],
     name: 'alice-bobbi',
-    packageIdentifier: 'com.alicebits',
+    nativePackageId: 'com.alicebits',
     githubAccount: 'alicebits',
     authorName: 'Alice',
     authorEmail: 'contact@alice.me',

--- a/tests/with-injection/create/with-options/with-package-name/__snapshots__/create-with-package-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-package-name/__snapshots__/create-with-package-name.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`create alice-bobbi module with moduleName: 'custom-native-module' 1`] = `
+exports[`create alice-bobbi module package with custom packageName 1`] = `
 Array [
   "* ensureDir dir: custom-native-module
 ",

--- a/tests/with-injection/create/with-options/with-package-name/__snapshots__/create-with-package-name.test.js.snap
+++ b/tests/with-injection/create/with-options/with-package-name/__snapshots__/create-with-package-name.test.js.snap
@@ -2,52 +2,52 @@
 
 exports[`create alice-bobbi module package with custom packageName 1`] = `
 Array [
-  "* ensureDir dir: custom-native-module
+  "* ensureDir dir: custom-native-module-package-name
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-package-name/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-package-name/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-package-name/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-package-name/
 ",
-  "* ensureDir dir: custom-native-module/android/
+  "* ensureDir dir: custom-native-module-package-name/android/
 ",
-  "* ensureDir dir: custom-native-module/android/src/main/
+  "* ensureDir dir: custom-native-module-package-name/android/src/main/
 ",
-  "* ensureDir dir: custom-native-module/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: custom-native-module-package-name/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: custom-native-module/android/src/main/java/com/reactlibrary/
+  "* ensureDir dir: custom-native-module-package-name/android/src/main/java/com/reactlibrary/
 ",
-  "* ensureDir dir: custom-native-module/android/
+  "* ensureDir dir: custom-native-module-package-name/android/
 ",
-  "* ensureDir dir: custom-native-module/
+  "* ensureDir dir: custom-native-module-package-name/
 ",
-  "* ensureDir dir: custom-native-module/ios/
+  "* ensureDir dir: custom-native-module-package-name/ios/
 ",
-  "* ensureDir dir: custom-native-module/ios/
+  "* ensureDir dir: custom-native-module-package-name/ios/
 ",
-  "* ensureDir dir: custom-native-module/ios/AliceBobbi.xcworkspace/
+  "* ensureDir dir: custom-native-module-package-name/ios/AliceBobbi.xcworkspace/
 ",
-  "* ensureDir dir: custom-native-module/ios/AliceBobbi.xcodeproj/
+  "* ensureDir dir: custom-native-module-package-name/ios/AliceBobbi.xcodeproj/
 ",
-  "* outputFile name: custom-native-module/README.md
+  "* outputFile name: custom-native-module-package-name/README.md
 content:
 --------
-# custom-native-module
+# custom-native-module-package-name
 
 ## Getting started
 
-\`$ npm install custom-native-module --save\`
+\`$ npm install custom-native-module-package-name --save\`
 
 ### Mostly automatic installation
 
-\`$ react-native link custom-native-module\`
+\`$ react-native link custom-native-module-package-name\`
 
 ## Usage
 \`\`\`javascript
-import AliceBobbi from 'custom-native-module';
+import AliceBobbi from 'custom-native-module-package-name';
 
 // TODO: What to do with the module?
 AliceBobbi;
@@ -55,12 +55,12 @@ AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/package.json
+  "* outputFile name: custom-native-module-package-name/package.json
 content:
 --------
 {
-  \\"name\\": \\"custom-native-module\\",
-  \\"title\\": \\"Custom Native Module\\",
+  \\"name\\": \\"custom-native-module-package-name\\",
+  \\"title\\": \\"Custom Native Module Package Name\\",
   \\"version\\": \\"1.0.0\\",
   \\"description\\": \\"TODO\\",
   \\"main\\": \\"index.js\\",
@@ -69,15 +69,15 @@ content:
     \\"android\\",
     \\"index.js\\",
     \\"ios\\",
-    \\"custom-native-module.podspec\\"
+    \\"custom-native-module-package-name.podspec\\"
   ],
   \\"scripts\\": {
     \\"test\\": \\"echo \\\\\\"Error: no test specified\\\\\\" && exit 1\\"
   },
   \\"repository\\": {
     \\"type\\": \\"git\\",
-    \\"url\\": \\"git+https://github.com/github_account/custom-native-module.git\\",
-    \\"baseUrl\\": \\"https://github.com/github_account/custom-native-module\\"
+    \\"url\\": \\"git+https://github.com/github_account/custom-native-module-package-name.git\\",
+    \\"baseUrl\\": \\"https://github.com/github_account/custom-native-module-package-name\\"
   },
   \\"keywords\\": [
     \\"react-native\\"
@@ -101,7 +101,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/index.js
+  "* outputFile name: custom-native-module-package-name/index.js
 content:
 --------
 // main index.js
@@ -114,7 +114,7 @@ export default AliceBobbi;
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/.gitignore
+  "* outputFile name: custom-native-module-package-name/.gitignore
 content:
 --------
 # OSX
@@ -162,7 +162,7 @@ buck-out/
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/build.gradle
+  "* outputFile name: custom-native-module-package-name/android/build.gradle
 content:
 --------
 // android/build.gradle
@@ -316,7 +316,7 @@ afterEvaluate { project ->
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/src/main/AndroidManifest.xml
+  "* outputFile name: custom-native-module-package-name/android/src/main/AndroidManifest.xml
 content:
 --------
 <!-- AndroidManifest.xml -->
@@ -328,7 +328,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
+  "* outputFile name: custom-native-module-package-name/android/src/main/java/com/reactlibrary/AliceBobbiModule.java
 content:
 --------
 // AliceBobbiModule.java
@@ -363,7 +363,7 @@ public class AliceBobbiModule extends ReactContextBaseJavaModule {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
+  "* outputFile name: custom-native-module-package-name/android/src/main/java/com/reactlibrary/AliceBobbiPackage.java
 content:
 --------
 // AliceBobbiPackage.java
@@ -393,7 +393,7 @@ public class AliceBobbiPackage implements ReactPackage {
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/android/README.md
+  "* outputFile name: custom-native-module-package-name/android/README.md
 content:
 --------
 README
@@ -413,30 +413,30 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/custom-native-module.podspec
+  "* outputFile name: custom-native-module-package-name/custom-native-module-package-name.podspec
 content:
 --------
-# custom-native-module.podspec
+# custom-native-module-package-name.podspec
 
 require \\"json\\"
 
 package = JSON.parse(File.read(File.join(__dir__, \\"package.json\\")))
 
 Pod::Spec.new do |s|
-  s.name         = \\"custom-native-module\\"
+  s.name         = \\"custom-native-module-package-name\\"
   s.version      = package[\\"version\\"]
   s.summary      = package[\\"description\\"]
   s.description  = <<-DESC
-                  custom-native-module
+                  custom-native-module-package-name
                    DESC
-  s.homepage     = \\"https://github.com/github_account/custom-native-module\\"
+  s.homepage     = \\"https://github.com/github_account/custom-native-module-package-name\\"
   # brief license entry:
   s.license      = \\"MIT\\"
   # optional - use expanded license entry instead:
   # s.license    = { :type => \\"MIT\\", :file => \\"LICENSE\\" }
   s.authors      = { \\"Your Name\\" => \\"yourname@email.com\\" }
   s.platforms    = { :ios => \\"9.0\\" }
-  s.source       = { :git => \\"https://github.com/github_account/custom-native-module.git\\", :tag => \\"#{s.version}\\" }
+  s.source       = { :git => \\"https://github.com/github_account/custom-native-module-package-name.git\\", :tag => \\"#{s.version}\\" }
 
   s.source_files = \\"ios/**/*.{h,c,cc,cpp,m,mm,swift}\\"
   s.requires_arc = true
@@ -449,7 +449,7 @@ end
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/ios/AliceBobbi.h
+  "* outputFile name: custom-native-module-package-name/ios/AliceBobbi.h
 content:
 --------
 // AliceBobbi.h
@@ -462,7 +462,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/ios/AliceBobbi.m
+  "* outputFile name: custom-native-module-package-name/ios/AliceBobbi.m
 content:
 --------
 // AliceBobbi.m
@@ -484,7 +484,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
+  "* outputFile name: custom-native-module-package-name/ios/AliceBobbi.xcworkspace/contents.xcworkspacedata
 content:
 --------
 <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
@@ -497,7 +497,7 @@ content:
 
 <<<<<<<< ======== >>>>>>>>
 ",
-  "* outputFile name: custom-native-module/ios/AliceBobbi.xcodeproj/project.pbxproj
+  "* outputFile name: custom-native-module-package-name/ios/AliceBobbi.xcodeproj/project.pbxproj
 content:
 --------
 // !$*UTF8*$!

--- a/tests/with-injection/create/with-options/with-package-name/create-with-package-name.test.js
+++ b/tests/with-injection/create/with-options/with-package-name/create-with-package-name.test.js
@@ -9,7 +9,7 @@ test(`create alice-bobbi module package with custom packageName`, async () => {
 
   const options = {
     name: 'alice-bobbi',
-    packageName: 'custom-native-module'
+    packageName: 'custom-native-module-package-name'
   };
 
   await lib(options, inject);

--- a/tests/with-injection/create/with-options/with-package-name/create-with-package-name.test.js
+++ b/tests/with-injection/create/with-options/with-package-name/create-with-package-name.test.js
@@ -2,14 +2,14 @@ const lib = require('../../../../../lib/lib.js');
 
 const ioInject = require('../../../helpers/io-inject.js');
 
-test(`create alice-bobbi module with moduleName: 'custom-native-module'`, async () => {
+test(`create alice-bobbi module package with custom packageName`, async () => {
   const mysnap = [];
 
   const inject = ioInject(mysnap);
 
   const options = {
     name: 'alice-bobbi',
-    moduleName: 'custom-native-module'
+    packageName: 'custom-native-module'
   };
 
   await lib(options, inject);

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/bogus-name/__snapshots__/cli-command-with-bogus-platforms-name.test.js.snap
@@ -4,7 +4,7 @@ exports[`create alice-bobbi module with logging, with platforms: 'bogus' 1`] = `
 Array [
   Object {
     "warn": Array [
-      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      "While \`{DEFAULT_NATIVE_PACKAGE_ID}\` is the default package
       identifier, it is recommended to customize the package identifier.",
     ],
   },
@@ -12,21 +12,20 @@ Array [
     "info": Array [
       "CREATE new React Native module with the following options:
 
-                     name: alice-bobbi
-    root moduleName
-      (full package name): react-native-alice-bobbi
-                  is view: false
- object class name prefix: 
-        object class name: AliceBobbi
-     library modulePrefix: react-native
-Android packageIdentifier: com.reactlibrary
-                platforms: bogus
-        Apple tvosEnabled: false
-               authorName: Your Name
-              authorEmail: yourname@email.com
-     author githubAccount: github_account
-                  license: MIT
-       useAppleNetworking: false
+                      name: alice-bobbi
+        full package name: react-native-alice-bobbi
+                   is view: false
+  object class name prefix: 
+         object class name: AliceBobbi
+      library modulePrefix: react-native
+   Android nativePackageId: com.reactlibrary
+                 platforms: bogus
+         Apple tvosEnabled: false
+                authorName: Your Name
+               authorEmail: yourname@email.com
+      author githubAccount: github_account
+                   license: MIT
+        useAppleNetworking: false
 ",
     ],
   },

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-bogus-platforms/empty-string/__snapshots__/cli-command-with-empty-platforms-string.test.js.snap
@@ -4,7 +4,7 @@ exports[`create alice-bobbi module with logging, with platforms: '' 1`] = `
 Array [
   Object {
     "warn": Array [
-      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      "While \`{DEFAULT_NATIVE_PACKAGE_ID}\` is the default package
       identifier, it is recommended to customize the package identifier.",
     ],
   },
@@ -12,21 +12,20 @@ Array [
     "info": Array [
       "CREATE new React Native module with the following options:
 
-                     name: alice-bobbi
-    root moduleName
-      (full package name): react-native-alice-bobbi
-                  is view: false
- object class name prefix: 
-        object class name: AliceBobbi
-     library modulePrefix: react-native
-Android packageIdentifier: com.reactlibrary
-                platforms: 
-        Apple tvosEnabled: false
-               authorName: Your Name
-              authorEmail: yourname@email.com
-     author githubAccount: github_account
-                  license: MIT
-       useAppleNetworking: false
+                      name: alice-bobbi
+        full package name: react-native-alice-bobbi
+                   is view: false
+  object class name prefix: 
+         object class name: AliceBobbi
+      library modulePrefix: react-native
+   Android nativePackageId: com.reactlibrary
+                 platforms: 
+         Apple tvosEnabled: false
+                authorName: Your Name
+               authorEmail: yourname@email.com
+      author githubAccount: github_account
+                   license: MIT
+        useAppleNetworking: false
 ",
     ],
   },

--- a/tests/with-mocks/cli/command/action-func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
+++ b/tests/with-mocks/cli/command/action-func/with-logging/with-error/__snapshots__/cli-command-with-logging-with-error.test.js.snap
@@ -4,7 +4,7 @@ exports[`create alice-bobbi module with logging, with fs error (with defaults fo
 Array [
   Object {
     "warn": Array [
-      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      "While \`{DEFAULT_NATIVE_PACKAGE_ID}\` is the default package
       identifier, it is recommended to customize the package identifier.",
     ],
   },
@@ -12,21 +12,20 @@ Array [
     "info": Array [
       "CREATE new React Native module with the following options:
 
-                     name: alice-bobbi
-    root moduleName
-      (full package name): react-native-alice-bobbi
-                  is view: false
- object class name prefix: 
-        object class name: AliceBobbi
-     library modulePrefix: react-native
-Android packageIdentifier: com.reactlibrary
-                platforms: android,ios
-        Apple tvosEnabled: false
-               authorName: Your Name
-              authorEmail: yourname@email.com
-     author githubAccount: github_account
-                  license: MIT
-       useAppleNetworking: false
+                      name: alice-bobbi
+        full package name: react-native-alice-bobbi
+                   is view: false
+  object class name prefix: 
+         object class name: AliceBobbi
+      library modulePrefix: react-native
+   Android nativePackageId: com.reactlibrary
+                 platforms: android,ios
+         Apple tvosEnabled: false
+                authorName: Your Name
+               authorEmail: yourname@email.com
+      author githubAccount: github_account
+                   license: MIT
+        useAppleNetworking: false
 ",
     ],
   },

--- a/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
+++ b/tests/with-mocks/cli/program/with-defaults/for-android/__snapshots__/cli-program-with-defaults-for-android.test.js.snap
@@ -30,8 +30,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--module-name [moduleName]",
-        "The module package name to be used in package.json. Default: react-native-(name in param-case)",
+        "--package-name [packageName]",
+        "The full package name to be used in package.json. Default: react-native-(name in param-case)",
         [Function],
         undefined,
       ],
@@ -80,8 +80,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--package-identifier [packageIdentifier]",
-        "[Android] The Java package identifier used by the Android module",
+        "--native-package-id [nativePackageId]",
+        "[Android] The native Java package identifier used for Android",
         [Function],
         "com.reactlibrary",
       ],
@@ -190,8 +190,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--example-react-native-version [exampleReactNativeVersion]",
-        "React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62",
+        "--example-react-native-template [exampleReactNativeTemplate]",
+        "The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62",
         [Function],
         "react-native@latest",
       ],

--- a/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
+++ b/tests/with-mocks/cli/program/with-example/with-logging/__snapshots__/cli-program-with-example-with-logging.test.js.snap
@@ -30,8 +30,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--module-name [moduleName]",
-        "The module package name to be used in package.json. Default: react-native-(name in param-case)",
+        "--package-name [packageName]",
+        "The full package name to be used in package.json. Default: react-native-(name in param-case)",
         [Function],
         undefined,
       ],
@@ -80,8 +80,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--package-identifier [packageIdentifier]",
-        "[Android] The Java package identifier used by the Android module",
+        "--native-package-id [nativePackageId]",
+        "[Android] The native Java package identifier used for Android",
         [Function],
         "com.reactlibrary",
       ],
@@ -190,8 +190,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--example-react-native-version [exampleReactNativeVersion]",
-        "React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62",
+        "--example-react-native-template [exampleReactNativeTemplate]",
+        "The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62",
         [Function],
         "react-native@latest",
       ],
@@ -218,7 +218,7 @@ Array [
   },
   Object {
     "warn": Array [
-      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      "While \`{DEFAULT_NATIVE_PACKAGE_ID}\` is the default package
       identifier, it is recommended to customize the package identifier.",
     ],
   },
@@ -226,27 +226,26 @@ Array [
     "info": Array [
       "CREATE new React Native module with the following options:
 
-                     name: test-package
-    root moduleName
-      (full package name): react-native-test-package
-                  is view: false
- object class name prefix: 
-        object class name: TestPackage
-     library modulePrefix: react-native
-Android packageIdentifier: com.reactlibrary
-                platforms: android,ios
-        Apple tvosEnabled: false
-               authorName: Your Name
-              authorEmail: yourname@email.com
-     author githubAccount: github_account
-                  license: MIT
-       useAppleNetworking: false
+                      name: test-package
+        full package name: react-native-test-package
+                   is view: false
+  object class name prefix: 
+         object class name: TestPackage
+      library modulePrefix: react-native
+   Android nativePackageId: com.reactlibrary
+                 platforms: android,ios
+         Apple tvosEnabled: false
+                authorName: Your Name
+               authorEmail: yourname@email.com
+      author githubAccount: github_account
+                   license: MIT
+        useAppleNetworking: false
 
-          generateExample: true
-       exampleFileLinkage: false
-              exampleName: example
-exampleReactNativeVersion: react-native@latest
-      writeExamplePodfile: false
+           generateExample: true
+        exampleFileLinkage: false
+               exampleName: example
+exampleReactNativeTemplate: react-native@latest
+       writeExamplePodfile: false
 ",
     ],
   },

--- a/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
+++ b/tests/with-mocks/cli/program/with-missing-args/__snapshots__/cli-program-with-missing-args.test.js.snap
@@ -28,8 +28,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--module-name [moduleName]",
-        "The module package name to be used in package.json. Default: react-native-(name in param-case)",
+        "--package-name [packageName]",
+        "The full package name to be used in package.json. Default: react-native-(name in param-case)",
         [Function],
         undefined,
       ],
@@ -78,8 +78,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--package-identifier [packageIdentifier]",
-        "[Android] The Java package identifier used by the Android module",
+        "--native-package-id [nativePackageId]",
+        "[Android] The native Java package identifier used for Android",
         [Function],
         "com.reactlibrary",
       ],
@@ -188,8 +188,8 @@ Array [
   Object {
     "option": Object {
       "args": Array [
-        "--example-react-native-version [exampleReactNativeVersion]",
-        "React Native template version for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62",
+        "--example-react-native-template [exampleReactNativeTemplate]",
+        "The React Native template used for the generated example project, for example: react-native-tvos or react-native-tvos@0.62.2-1 (requires --tvos-enabled option); react-native@0.62",
         [Function],
         "react-native@latest",
       ],

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-defaults/__snapshots__/create-with-example-with-defaults.test.js.snap
@@ -4,7 +4,7 @@ exports[`create alice-bobbi module using mocked lib with logging, with example, 
 Array [
   Object {
     "warn": Array [
-      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      "While \`{DEFAULT_NATIVE_PACKAGE_ID}\` is the default package
       identifier, it is recommended to customize the package identifier.",
     ],
   },
@@ -12,27 +12,26 @@ Array [
     "info": Array [
       "CREATE new React Native module with the following options:
 
-                     name: alice-bobbi
-    root moduleName
-      (full package name): react-native-alice-bobbi
-                  is view: false
- object class name prefix: 
-        object class name: AliceBobbi
-     library modulePrefix: react-native
-Android packageIdentifier: com.reactlibrary
-                platforms: android,ios
-        Apple tvosEnabled: false
-               authorName: Your Name
-              authorEmail: yourname@email.com
-     author githubAccount: github_account
-                  license: MIT
-       useAppleNetworking: false
+                      name: alice-bobbi
+        full package name: react-native-alice-bobbi
+                   is view: false
+  object class name prefix: 
+         object class name: AliceBobbi
+      library modulePrefix: react-native
+   Android nativePackageId: com.reactlibrary
+                 platforms: android,ios
+         Apple tvosEnabled: false
+                authorName: Your Name
+               authorEmail: yourname@email.com
+      author githubAccount: github_account
+                   license: MIT
+        useAppleNetworking: false
 
-          generateExample: true
-       exampleFileLinkage: false
-              exampleName: example
-exampleReactNativeVersion: react-native@latest
-      writeExamplePodfile: false
+           generateExample: true
+        exampleFileLinkage: false
+               exampleName: example
+exampleReactNativeTemplate: react-native@latest
+       writeExamplePodfile: false
 ",
     ],
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-error/__snapshots__/with-yarn-error-logging.test.js.snap
@@ -4,7 +4,7 @@ exports[`create alice-bobbi module using mocked lib with example, with \`yarn ad
 Array [
   Object {
     "warn": Array [
-      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      "While \`{DEFAULT_NATIVE_PACKAGE_ID}\` is the default package
       identifier, it is recommended to customize the package identifier.",
     ],
   },
@@ -12,27 +12,26 @@ Array [
     "info": Array [
       "CREATE new React Native module with the following options:
 
-                     name: alice-bobbi
-    root moduleName
-      (full package name): react-native-alice-bobbi
-                  is view: false
- object class name prefix: 
-        object class name: AliceBobbi
-     library modulePrefix: react-native
-Android packageIdentifier: com.reactlibrary
-                platforms: android,ios
-        Apple tvosEnabled: false
-               authorName: Your Name
-              authorEmail: yourname@email.com
-     author githubAccount: github_account
-                  license: MIT
-       useAppleNetworking: false
+                      name: alice-bobbi
+        full package name: react-native-alice-bobbi
+                   is view: false
+  object class name prefix: 
+         object class name: AliceBobbi
+      library modulePrefix: react-native
+   Android nativePackageId: com.reactlibrary
+                 platforms: android,ios
+         Apple tvosEnabled: false
+                authorName: Your Name
+               authorEmail: yourname@email.com
+      author githubAccount: github_account
+                   license: MIT
+        useAppleNetworking: false
 
-          generateExample: true
-       exampleFileLinkage: false
-              exampleName: example
-exampleReactNativeVersion: react-native@latest
-      writeExamplePodfile: false
+           generateExample: true
+        exampleFileLinkage: false
+               exampleName: example
+exampleReactNativeTemplate: react-native@latest
+       writeExamplePodfile: false
 ",
     ],
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-null-options/with-null-prefix/__snapshots__/create-with-example-with-options.test.js.snap
@@ -4,7 +4,7 @@ exports[`create alice-bobbi module using mocked lib with logging, with example, 
 Array [
   Object {
     "warn": Array [
-      "While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      "While \`{DEFAULT_NATIVE_PACKAGE_ID}\` is the default package
       identifier, it is recommended to customize the package identifier.",
     ],
   },
@@ -12,27 +12,26 @@ Array [
     "info": Array [
       "CREATE new React Native module with the following options:
 
-                     name: alice-bobbi
-    root moduleName
-      (full package name): react-native-alice-bobbi
-                  is view: false
- object class name prefix: null
-        object class name: AliceBobbi
-     library modulePrefix: react-native
-Android packageIdentifier: com.reactlibrary
-                platforms: android,ios
-        Apple tvosEnabled: false
-               authorName: Your Name
-              authorEmail: yourname@email.com
-     author githubAccount: github_account
-                  license: MIT
-       useAppleNetworking: false
+                      name: alice-bobbi
+        full package name: react-native-alice-bobbi
+                   is view: false
+  object class name prefix: null
+         object class name: AliceBobbi
+      library modulePrefix: react-native
+   Android nativePackageId: com.reactlibrary
+                 platforms: android,ios
+         Apple tvosEnabled: false
+                authorName: Your Name
+               authorEmail: yourname@email.com
+      author githubAccount: github_account
+                   license: MIT
+        useAppleNetworking: false
 
-          generateExample: true
-       exampleFileLinkage: false
-              exampleName: example
-exampleReactNativeVersion: react-native@latest
-      writeExamplePodfile: false
+           generateExample: true
+        exampleFileLinkage: false
+               exampleName: example
+exampleReactNativeTemplate: react-native@latest
+       writeExamplePodfile: false
 ",
     ],
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/__snapshots__/create-with-example-with-options.test.js.snap
@@ -6,27 +6,26 @@ Array [
     "info": Array [
       "CREATE new React Native module with the following options:
 
-                     name: alice-bobbi
-    root moduleName
-      (full package name): react-native-alice-bobbi
-                  is view: false
- object class name prefix: ABC
-        object class name: ABCAliceBobbi
-     library modulePrefix: react-native
-Android packageIdentifier: com.alicebits
-                platforms: android,ios
-        Apple tvosEnabled: true
-               authorName: Alice
-              authorEmail: contact@alice.me
-     author githubAccount: alicebits
-                  license: ISC
-       useAppleNetworking: false
+                      name: alice-bobbi
+        full package name: react-native-alice-bobbi
+                   is view: false
+  object class name prefix: ABC
+         object class name: ABCAliceBobbi
+      library modulePrefix: react-native
+   Android nativePackageId: com.alicebits
+                 platforms: android,ios
+         Apple tvosEnabled: true
+                authorName: Alice
+               authorEmail: contact@alice.me
+      author githubAccount: alicebits
+                   license: ISC
+        useAppleNetworking: false
 
-          generateExample: true
-       exampleFileLinkage: true
-              exampleName: demo
-exampleReactNativeVersion: react-native@npm:react-native-tvos
-      writeExamplePodfile: false
+           generateExample: true
+        exampleFileLinkage: true
+               exampleName: demo
+exampleReactNativeTemplate: react-native@npm:react-native-tvos
+       writeExamplePodfile: false
 ",
     ],
   },

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/create-with-example-with-options.test.js
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/create-with-example-with-options.test.js
@@ -70,7 +70,7 @@ test('create alice-bobbi module using mocked lib with logging, with example, for
     generateExample: true,
     exampleFileLinkage: true,
     exampleName: 'demo',
-    exampleReactNativeVersion: 'react-native@npm:react-native-tvos'
+    exampleReactNativeTemplate: 'react-native@npm:react-native-tvos'
   };
 
   await lib(options);

--- a/tests/with-mocks/lib/create/with-example/with-logging/with-options/create-with-example-with-options.test.js
+++ b/tests/with-mocks/lib/create/with-example/with-logging/with-options/create-with-example-with-options.test.js
@@ -61,7 +61,7 @@ test('create alice-bobbi module using mocked lib with logging, with example, for
     platforms: ['android', 'ios'],
     name: 'alice-bobbi',
     prefix: 'ABC',
-    packageIdentifier: 'com.alicebits',
+    nativePackageId: 'com.alicebits',
     tvosEnabled: true,
     githubAccount: 'alicebits',
     authorName: 'Alice',


### PR DESCRIPTION
(part of release `0.2.0` as discussed in #409)

- rename `--module-name` option to `--package-name`
- rename `--package-identifier` option to '--native-package-id`
- rename `--example-react-native-version` to `--example-react-native-template`
- update description & help text of the affected options
- add a space to indenting of options in logging

BREAKING CHANGE: affects anyone using the renamed options